### PR TITLE
[Issue-7] Adjust sheet header appearance

### DIFF
--- a/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView.Appearance+Layout.swift
+++ b/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView.Appearance+Layout.swift
@@ -15,20 +15,24 @@ extension DragIndicatorView.Appearance {
         public var cornerRadius: CGFloat
         /// Size for the drag indicator. Default is {60, 4}.
         public var size: CGSize
-        
+        /// Inset of indicator from top of sheet. Default is `8.0`
+        public var topInset: CGFloat
         /// Default layout.
-        public static var `default` = Layout(cornerRadius: 2.0, size: CGSize(width: 60, height: 4))
+        public static var `default` = Layout()
         
         /// Initializes a `Layout`.
         /// - Parameters:
         ///   - cornerRadius: corner radius of drag indicator.
         ///   - size: size for the drag indicator.
+        ///   - topInset: inset of indicator from top of sheet.
         public init(
-            cornerRadius: CGFloat,
-            size: CGSize
+            cornerRadius: CGFloat = 2,
+            size: CGSize = CGSize(width: 60, height: 4),
+            topInset: CGFloat = 8
         ) {
             self.cornerRadius = cornerRadius
             self.size = size
+            self.topInset = topInset
         }
     }
 }

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -61,7 +61,7 @@ final class BottomSheetControllerTests: XCTestCase {
         XCTAssertFalse(sut.isResizable)
         XCTAssertFalse(sut.hasHeader)
         XCTAssertTrue(sut.headerView.isHidden)
-        XCTAssertTrue(sut.indicatorView.isHidden)
+        XCTAssertTrue(sut.indicatorContainer.isHidden)
         XCTAssertEqual(sut.appearance.layout.cornerRadius, radius)
         XCTAssertEqual(sut.dimmerView.backgroundColor, appearance.dimmerColor)
     }
@@ -127,7 +127,7 @@ final class BottomSheetControllerTests: XCTestCase {
             indicatorAppearance: nil
         )
         
-        XCTAssertTrue(sut.indicatorView.isHidden)
+        XCTAssertTrue(sut.indicatorContainer.isHidden)
         XCTAssertFalse(sut.isResizable)
     }
     

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewAppearanceLayoutTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewAppearanceLayoutTests.swift
@@ -14,14 +14,17 @@ final class DragIndicatorViewAppearanceLayoutTests: XCTestCase {
         let sut = DragIndicatorView.Appearance.Layout.default
         XCTAssertEqual(sut.cornerRadius, 2)
         XCTAssertEqual(sut.size, CGSize(width: 60, height: 4))
+        XCTAssertEqual(sut.topInset, 8)
     }
     
-    func test_propertiesWithRandomValues() {
+    func test_propertiesWithCustomValues() {
         let sut = DragIndicatorView.Appearance.Layout(
             cornerRadius: 8,
-            size: CGSize(width: 100, height: 16)
+            size: CGSize(width: 100, height: 16),
+            topInset: 24
         )
         XCTAssertEqual(sut.cornerRadius, 8)
         XCTAssertEqual(sut.size, CGSize(width: 100, height: 16))
+        XCTAssertEqual(sut.topInset, 24)
     }
 }

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
@@ -22,16 +22,18 @@ final class DragIndicatorViewTests: XCTestCase {
         XCTAssertEqual(sut.appearance.color, .tertiaryLabel)
         XCTAssertEqual(sut.appearance.layout.cornerRadius, 2)
         XCTAssertEqual(sut.appearance.layout.size, CGSize(width: 60, height: 4))
+        XCTAssertEqual(sut.appearance.layout.topInset, 8)
         XCTAssertEqual(sut.intrinsicContentSize, CGSize(width: 60, height: 4))
     }
     
-    func test_init_withRandomValues() {
+    func test_init_withCustomValues() {
         let size = CGSize(width: 100, height: 20)
         let appearance = DragIndicatorView.Appearance(
             color: .red,
             layout: DragIndicatorView.Appearance.Layout(
                 cornerRadius: 10,
-                size: size
+                size: size,
+                topInset: 12
             )
         )
         let sut = makeSUT(appearance: appearance)
@@ -39,6 +41,7 @@ final class DragIndicatorViewTests: XCTestCase {
         XCTAssertEqual(sut.appearance.color, .red)
         XCTAssertEqual(sut.appearance.layout.cornerRadius, 10)
         XCTAssertEqual(sut.appearance.layout.size, size)
+        XCTAssertEqual(sut.appearance.layout.topInset, 12)
         XCTAssertEqual(sut.intrinsicContentSize, size)
     }
     
@@ -57,16 +60,18 @@ final class DragIndicatorViewTests: XCTestCase {
         let sut = makeSUT()
         let size = CGSize(width: 100, height: 8)
         let radius: CGFloat = 4
+        let topInset: CGFloat = 10
 
         XCTAssertNotEqual(sut.appearance.layout.cornerRadius, radius)
         XCTAssertNotEqual(sut.appearance.layout.size, size)
 
         sut.appearance = DragIndicatorView.Appearance(
-            layout: DragIndicatorView.Appearance.Layout(cornerRadius: radius, size: size)
+            layout: DragIndicatorView.Appearance.Layout(cornerRadius: radius, size: size, topInset: 10)
         )
 
         XCTAssertEqual(sut.appearance.layout.cornerRadius, radius)
         XCTAssertEqual(sut.appearance.layout.size, size)
+        XCTAssertEqual(sut.appearance.layout.topInset, topInset)
     }
 }
 


### PR DESCRIPTION
## Introduction ##

There should be no unsightly gap above the header for fixed size sheets (no drag indicator).

## Purpose ##

Refactor sheet layout to have zero gap above the header (if any) for fixed size sheets.
Fix #7 

## Scope ##

* Refactor BottomSheetController layout
* Refactor DragIndicatorView.Appearance.Layout
* Update unit tests

## Discussion ##

The layout of the area above the heading was weird. Even with the drag indicator, the offset from the sheet top to drag indicator top was = sheet.cornerRadius - indicator.layout.height, which made little sense. Now there's a simple property `topInset` that positions the indicator within the sheet and is independent of sheet corner radius.  For resizable sheets, the height of the drag area = topInset + indicator.height. For fixed sheets, that view is hidden and has a height of 0.

For resizable sheets the drag indicator by default is closer to the top of the sheet (now: 8, before: 16 - 4 = 12).

## 📱 Screenshots ##

| Before | After |
| ------------- | ------------- |
| ![Sheet-7-before-none](https://user-images.githubusercontent.com/1037520/225531525-d98141d0-3d54-4863-b328-fff6adcad989.png)  | ![Sheet-7-after-none](https://user-images.githubusercontent.com/1037520/225531660-f475158a-f905-4671-9f35-bc9fcb94f0fc.png)  |
| ![Sheet-7-before-title-only](https://user-images.githubusercontent.com/1037520/225531741-283d06a1-cb8b-4f57-b5eb-11e34a135ed5.png) | ![Sheet-7-after-title-only](https://user-images.githubusercontent.com/1037520/225531735-414590c4-7a77-4d44-82d4-0fddf569dc94.png) |
| ![Sheet-7-before-drag-only](https://user-images.githubusercontent.com/1037520/225531744-106cf557-4483-4663-ac14-387ec51ca598.png) | ![Sheet-7-after-drag-only](https://user-images.githubusercontent.com/1037520/225531750-4c428042-10ff-4665-91b2-cc940f59524f.png) |
| ![Sheet-7-before-drag-title](https://user-images.githubusercontent.com/1037520/225531740-13ed314b-afcb-4154-be5e-e56a0aab8bcd.png) | ![Sheet-7-after-drag-title](https://user-images.githubusercontent.com/1037520/225531749-8753a822-d3a5-4286-b872-53076b151c13.png) |

## 📈 Coverage ##

##### Code #####

100%

<img width="665" alt="image" src="https://user-images.githubusercontent.com/1037520/225531346-0dda896b-5f78-4c02-9738-d2d06a524fdf.png">

##### Documentation #####

100%

<img width="605" alt="image" src="https://user-images.githubusercontent.com/1037520/225531223-97a38557-c061-4f6e-af3b-ce06396d8dad.png">
