### PR TITLE
[CM-1261] Add option to disable dismiss UI.

### DIFF
--- a/Sources/YBottomSheet/BottomSheetController+Animation.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Animation.swift
@@ -1,0 +1,27 @@
+//
+//  BottomSheetController.swift
+//  YBottomSheet
+//
+//  Created by Dev Karan on 22/31/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+extension BottomSheetController: UIViewControllerTransitioningDelegate {
+    /// Returns the animator for presenting a bottom sheet
+    public func animationController(
+        forPresented presented: UIViewController,
+        presenting: UIViewController,
+        source: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        BottomSheetPresentAnimator(sheetViewController: self)
+    }
+    
+    /// Returns the animator for dismissing a bottom sheet
+    public func animationController(
+        forDismissed dismissed: UIViewController
+    ) -> UIViewControllerAnimatedTransitioning? {
+        BottomSheetDismissAnimator(sheetViewController: self)
+    }
+}

--- a/Sources/YBottomSheet/BottomSheetController+Appearance.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance.swift
@@ -32,7 +32,9 @@ extension BottomSheetController {
         ///
         /// Only applicable for resizable sheets. `nil` means to use the content view's intrinsic height as the minimum.
         public var minimumContentHeight: CGFloat?
-        
+        /// Whether the sheet is dismissible or not. Default is `true`.
+        public var allowDismiss: Bool
+
         /// Default appearance (fixed size sheet)
         public static let `default` = Appearance()
         /// Default appearance for a resizable sheet
@@ -49,6 +51,7 @@ extension BottomSheetController {
         ///   - presentAnimationCurve: Animaiton during presenting.
         ///   - dismissAnimationCurve: Animation during dismiss.
         ///   - minimumContentHeight: Optional) Minimum content view height.
+        ///   - allowDismiss: Whether the sheet is dismissible or not.
         public init(
             indicatorAppearance: DragIndicatorView.Appearance? = nil,
             headerAppearance: SheetHeaderView.Appearance? = .default,
@@ -58,7 +61,8 @@ extension BottomSheetController {
             animationDuration: TimeInterval = 0.3,
             presentAnimationCurve: UIView.AnimationOptions = .curveEaseIn,
             dismissAnimationCurve: UIView.AnimationOptions = .curveEaseOut,
-            minimumContentHeight: CGFloat? = nil
+            minimumContentHeight: CGFloat? = nil,
+            allowDismiss: Bool = true
         ) {
             self.indicatorAppearance = indicatorAppearance
             self.headerAppearance = headerAppearance
@@ -69,6 +73,7 @@ extension BottomSheetController {
             self.presentAnimationCurve = presentAnimationCurve
             self.dismissAnimationCurve = dismissAnimationCurve
             self.minimumContentHeight = minimumContentHeight
+            self.allowDismiss = allowDismiss
         }
     }
 }

--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -149,6 +149,14 @@ public class BottomSheetController: UIViewController {
         didDismiss()
         return true
     }
+    
+    /// Dismiss bottom sheet.
+    /// - Parameter isCloseButton: whether close button is tapped or not.
+    func didDismiss(isCloseButton: Bool = false) {
+        if appearance.allowDismiss || isCloseButton {
+            onDismiss()
+        }
+    }
 }
 
 private extension BottomSheetController {
@@ -308,8 +316,8 @@ private extension BottomSheetController {
 
 extension BottomSheetController: SheetHeaderViewDelegate {
     @objc
-    func didDismiss() {
-        onDismiss()
+    func didCloseTapped() {
+        didDismiss(isCloseButton: true)
     }
 }
 
@@ -352,24 +360,6 @@ private extension BottomSheetController {
     }
 }
 
-extension BottomSheetController: UIViewControllerTransitioningDelegate {
-    /// Returns the animator for presenting a bottom sheet
-    public func animationController(
-        forPresented presented: UIViewController,
-        presenting: UIViewController,
-        source: UIViewController
-    ) -> UIViewControllerAnimatedTransitioning? {
-        BottomSheetPresentAnimator(sheetViewController: self)
-    }
-    
-    /// Returns the animator for dismissing a bottom sheet
-    public func animationController(
-        forDismissed dismissed: UIViewController
-    ) -> UIViewControllerAnimatedTransitioning? {
-        BottomSheetDismissAnimator(sheetViewController: self)
-    }
-}
-
 // Methods for unit testing
 internal extension BottomSheetController {
     @objc
@@ -392,6 +382,6 @@ internal extension BottomSheetController {
 
     @objc
     func simulateDismiss() {
-        didDismiss()
+        didCloseTapped()
     }
 }

--- a/Sources/YBottomSheet/Protocols/SheetHeaderViewDelegate.swift
+++ b/Sources/YBottomSheet/Protocols/SheetHeaderViewDelegate.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 internal protocol SheetHeaderViewDelegate: AnyObject {
-    func didDismiss()
+    func didCloseTapped()
 }

--- a/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
+++ b/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
@@ -51,7 +51,7 @@ open class SheetHeaderView: UIView {
     required public init?(coder: NSCoder) { nil }
     
     @objc private func closeButtonAction() {
-        delegate?.didDismiss()
+        delegate?.didCloseTapped()
     }
     
     // For unit testing

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -130,40 +130,6 @@ final class BottomSheetControllerTests: XCTestCase {
         XCTAssertTrue(sut.indicatorContainer.isHidden)
         XCTAssertFalse(sut.isResizable)
     }
-    
-    func test_onDimmer() {
-        let sut = SpyBottomSheetController(title: "", childView: UIView())
-        
-        XCTAssertFalse(sut.onDimmerTapped)
-        XCTAssertFalse(sut.isDismissed)
-
-        sut.simulateOnDimmerTap()
-        
-        XCTAssertTrue(sut.onDimmerTapped)
-        XCTAssertTrue(sut.isDismissed)
-    }
-    
-    func test_onSwipeDown() {
-        let sut = SpyBottomSheetController(title: "", childView: UIView())
-        
-        XCTAssertFalse(sut.onSwipeDown)
-        XCTAssertFalse(sut.isDismissed)
-
-        sut.simulateOnSwipeDown()
-        
-        XCTAssertTrue(sut.onSwipeDown)
-        XCTAssertTrue(sut.isDismissed)
-    }
-    
-    func test_onDidDismiss() {
-        let sut = SpyBottomSheetController(title: "", childView: UIView())
-        
-        XCTAssertFalse(sut.isDismissed)
-        
-        sut.simulateDismiss()
-        
-        XCTAssertTrue(sut.isDismissed)
-    }
 
     func test_dragging_worksIfResizable() {
         let sut = SpyBottomSheetController(title: "", childView: ChildView(), appearance: .defaultResizable)
@@ -324,6 +290,56 @@ final class BottomSheetControllerTests: XCTestCase {
     }
 }
 
+extension BottomSheetControllerTests {
+    func test_onDimmer() {
+        let sut = SpyBottomSheetController(title: "", childView: UIView())
+        
+        XCTAssertFalse(sut.onDimmerTapped)
+        XCTAssertFalse(sut.isDismissed)
+
+        sut.simulateOnDimmerTap()
+        
+        XCTAssertTrue(sut.onDimmerTapped)
+        XCTAssertTrue(sut.isDismissed)
+    }
+    
+    func test_onSwipeDown() {
+        let sut = SpyBottomSheetController(title: "", childView: UIView())
+        
+        XCTAssertFalse(sut.onSwipeDown)
+        XCTAssertFalse(sut.isDismissed)
+
+        sut.simulateOnSwipeDown()
+        
+        XCTAssertTrue(sut.onSwipeDown)
+        XCTAssertTrue(sut.isDismissed)
+    }
+    
+    func test_onDidDismiss() {
+        let sut = SpyBottomSheetController(title: "", childView: UIView())
+        
+        XCTAssertFalse(sut.isDismissed)
+        
+        sut.simulateDismiss()
+        
+        XCTAssertTrue(sut.isDismissed)
+    }
+    
+    func test_forbidDismiss() {
+        let sut = SpyBottomSheetController(title: "", childView: UIView())
+        sut.appearance.allowDismiss = false
+        
+        XCTAssertFalse(sut.onSwipeDown)
+        XCTAssertFalse(sut.onDimmerTapped)
+        
+        sut.simulateOnDimmerTap()
+        sut.simulateOnSwipeDown()
+        
+        XCTAssertFalse(sut.onSwipeDown)
+        XCTAssertFalse(sut.onDimmerTapped)
+    }
+}
+
 private extension BottomSheetControllerTests {
     func makeSUT(
         viewController: UIViewController,
@@ -368,19 +384,25 @@ final class SpyBottomSheetController: BottomSheetController {
     var onDimmerTapped = false
     var onDragging = false
 
-    override func didDismiss() {
+    override func didDismiss(isCloseButton: Bool) {
         super.didDismiss()
-        isDismissed = true
+        if isCloseButton || appearance.allowDismiss {
+            isDismissed = true
+        }
     }
 
     override func simulateOnSwipeDown() {
         super.simulateOnSwipeDown()
-        onSwipeDown = true
+        if appearance.allowDismiss {
+            onSwipeDown = true
+        }
     }
 
     override func simulateOnDimmerTap() {
         super.simulateOnDimmerTap()
-        onDimmerTapped = true
+        if appearance.allowDismiss {
+            onDimmerTapped = true
+        }
     }
 
     @discardableResult

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
@@ -91,7 +91,7 @@ private extension SheetHeaderViewTests {
 }
 
 extension SheetHeaderViewTests: SheetHeaderViewDelegate {
-    func didDismiss() {
+    func didCloseTapped() {
         isDismissed = true
     }
 }


### PR DESCRIPTION
## Introduction ##

Introduced new option to disable dismiss.

## Purpose ##

- We have no way of disabling the swipe down, tap on dimmer, or accessibility escape gesture which were use to dismissing the sheet. 
- Fix #13 

## Scope ##

We have added a new property `allowDismiss` in appearance. If it is true then we can dismiss the bottom sheet else we are suspending the dismiss action


## 📈 Coverage ##

##### Code #####

<img width="1053" alt="Screenshot 2023-03-22 at 1 27 47 PM" src="https://user-images.githubusercontent.com/102538361/226836646-49936bbc-e9e1-489f-b098-fb9f715893c5.png">

##### Documentation #####
<img width="796" alt="Screenshot 2023-03-22 at 1 30 10 PM" src="https://user-images.githubusercontent.com/102538361/226837140-e42a0871-8832-453f-945a-afa3e01466c2.png">

