### PR TITLE
[CM-1243] Support for reduce motion accessibility.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 
 import PackageDescription
 
@@ -17,11 +17,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.4.0"
+            from: "1.5.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",
-            from: "1.4.0"
+            from: "1.6.0"
         )
     ],
     targets: [

--- a/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
@@ -13,6 +13,13 @@ class BottomSheetAnimator: NSObject {
     /// Bottom sheet controller.
     let sheetViewController: BottomSheetController
     
+    /// Accessibility reduce motion is enabled or not.
+    var isReduceMotionEnabled: Bool {
+        get {
+            UIAccessibility.isReduceMotionEnabled
+        }
+    }
+    
     /// Initializes a bottom sheet animator.
     /// - Parameter sheetViewController: the sheet being animated.
     init(sheetViewController: BottomSheetController) {

--- a/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
@@ -15,9 +15,7 @@ class BottomSheetAnimator: NSObject {
     
     /// Accessibility reduce motion is enabled or not.
     var isReduceMotionEnabled: Bool {
-        get {
-            UIAccessibility.isReduceMotionEnabled
-        }
+        UIAccessibility.isReduceMotionEnabled
     }
     
     /// Initializes a bottom sheet animator.

--- a/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetAnimator.swift
@@ -12,10 +12,16 @@ import UIKit
 class BottomSheetAnimator: NSObject {
     /// Bottom sheet controller.
     let sheetViewController: BottomSheetController
-    
+
+    /// Override for isReduceMotionEnabled. Default is `nil`.
+    ///
+    /// For unit testing. When non-`nil` it will be returned instead of
+    /// `UIAccessibility.isReduceMotionEnabled`,
+    var reduceMotionOverride: Bool?
+
     /// Accessibility reduce motion is enabled or not.
     var isReduceMotionEnabled: Bool {
-        UIAccessibility.isReduceMotionEnabled
+        reduceMotionOverride ?? UIAccessibility.isReduceMotionEnabled
     }
     
     /// Initializes a bottom sheet animator.

--- a/Sources/YBottomSheet/Animation/BottomSheetDismissAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetDismissAnimator.swift
@@ -37,7 +37,9 @@ class BottomSheetDismissAnimator: BottomSheetAnimator {
             delay: .zero,
             options: [.beginFromCurrentState, sheet.appearance.dismissAnimationCurve]
         ) {
-            sheet.sheetView.frame = sheetFrame
+            if !self.isReduceMotionEnabled {
+                sheet.sheetView.frame = sheetFrame
+            }
         } completion: { _ in
             if !transitionContext.transitionWasCancelled {
                 fromViewController.view.removeFromSuperview()

--- a/Sources/YBottomSheet/Animation/BottomSheetDismissAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetDismissAnimator.swift
@@ -37,7 +37,9 @@ class BottomSheetDismissAnimator: BottomSheetAnimator {
             delay: .zero,
             options: [.beginFromCurrentState, sheet.appearance.dismissAnimationCurve]
         ) {
-            if !self.isReduceMotionEnabled {
+            if self.isReduceMotionEnabled {
+                sheet.sheetView.alpha = 0
+            } else {
                 sheet.sheetView.frame = sheetFrame
             }
         } completion: { _ in

--- a/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
@@ -21,7 +21,9 @@ class BottomSheetPresentAnimator: BottomSheetAnimator {
         sheet.view.layoutSubviews()
         sheet.dimmerView.alpha = 0
         
-        if !isReduceMotionEnabled {
+        if isReduceMotionEnabled {
+            sheet.sheetView.alpha = 0
+        } else {
             let toFinalFrame = transitionContext.finalFrame(for: toViewController)
             var sheetFrame = sheet.sheetView.frame
             sheetFrame.origin.y = toFinalFrame.maxY + (sheet.appearance.elevation?.extent.top ?? 0)
@@ -44,7 +46,11 @@ class BottomSheetPresentAnimator: BottomSheetAnimator {
             delay: .zero,
             options: [.beginFromCurrentState, sheet.appearance.presentAnimationCurve]
         ) {
-            sheet.view.layoutIfNeeded()
+            if self.isReduceMotionEnabled {
+                sheet.sheetView.alpha = 1
+            } else {
+                sheet.view.layoutIfNeeded()
+            }
         } completion: { _ in
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
         }

--- a/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
@@ -21,11 +21,13 @@ class BottomSheetPresentAnimator: BottomSheetAnimator {
         sheet.view.layoutSubviews()
         sheet.dimmerView.alpha = 0
         
-        let toFinalFrame = transitionContext.finalFrame(for: toViewController)
-        var sheetFrame = sheet.sheetView.frame
-        sheetFrame.origin.y = toFinalFrame.maxY + (sheet.appearance.elevation?.extent.top ?? 0)
-        sheet.sheetView.frame = sheetFrame
-        sheet.view.setNeedsLayout()
+        if !isReduceMotionEnabled {
+            let toFinalFrame = transitionContext.finalFrame(for: toViewController)
+            var sheetFrame = sheet.sheetView.frame
+            sheetFrame.origin.y = toFinalFrame.maxY + (sheet.appearance.elevation?.extent.top ?? 0)
+            sheet.sheetView.frame = sheetFrame
+            sheet.view.setNeedsLayout()
+        }
         
         let duration = transitionDuration(using: transitionContext)
         

--- a/Tests/YBottomSheetTests/Animation/BottomSheetDismissAnimatorTests.swift
+++ b/Tests/YBottomSheetTests/Animation/BottomSheetDismissAnimatorTests.swift
@@ -11,11 +11,7 @@ import XCTest
 
 final class BottomSheetDismissAnimatorTests: XCTestCase {
     func test_animate() throws {
-        let sheetController = BottomSheetController(
-            title: "Bottom Sheet",
-            childView: UIView(),
-            appearance: BottomSheetController.Appearance(animationDuration: 0.0)
-        )
+        let sheetController = makeSheet()
         let (sut, context) = try makeSUT(sheetViewController: sheetController, to: sheetController)
 
         XCTAssertTrue(sut is BottomSheetDismissAnimator)
@@ -26,15 +22,44 @@ final class BottomSheetDismissAnimatorTests: XCTestCase {
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         XCTAssertTrue(context.wasCompleteCalled)
         XCTAssertTrue(context.didComplete)
+    }
+
+    func test_animateWithoutReduceMotion_TranslatesDown() throws {
+        let sheetController = makeSheet()
+        let (sut, context) = try makeSUT(
+            sheetViewController: sheetController,
+            to: sheetController,
+            isReduceMotionEnabled: false
+        )
+
+        sut.animateTransition(using: context)
+
+        // Wait for the run loop to tick (animate keyboard)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         XCTAssertEqual(sheetController.dimmerView.alpha, 0)
+        XCTAssertEqual(sheetController.sheetView.alpha, 1)
         XCTAssertEqual(sheetController.sheetView.frame.minY, context.containerView.bounds.maxY)
     }
 
-    func test_animateWithoutTo_Fails() throws {
-        let sheetController = BottomSheetController(
-            title: "Bottom Sheet",
-            childView: UIView()
+    func test_animateWithReduceMotion_FadesOut() throws {
+        let sheetController = makeSheet()
+        let (sut, context) = try makeSUT(
+            sheetViewController: sheetController,
+            to: sheetController,
+            isReduceMotionEnabled: true
         )
+
+        sut.animateTransition(using: context)
+
+        // Wait for the run loop to tick (animate keyboard)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+        XCTAssertEqual(sheetController.dimmerView.alpha, 0)
+        XCTAssertEqual(sheetController.sheetView.alpha, 0)
+        XCTAssertLessThan(sheetController.sheetView.frame.minY, context.containerView.bounds.maxY)
+    }
+
+    func test_animateWithoutTo_Fails() throws {
+        let sheetController = makeSheet()
         let (sut, context) = try makeSUT(sheetViewController: sheetController, to: nil)
 
         XCTAssertFalse(context.wasCompleteCalled)
@@ -49,14 +74,31 @@ private extension BottomSheetDismissAnimatorTests {
     func makeSUT(
         sheetViewController: BottomSheetController,
         to: UIViewController?,
+        isReduceMotionEnabled: Bool? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (UIViewControllerAnimatedTransitioning, MockAnimationContext) {
         let main = UIViewController()
-        let animator = try XCTUnwrap(sheetViewController.animationController(forDismissed: sheetViewController))
+        let animator = try XCTUnwrap(
+            sheetViewController.animationController(forDismissed: sheetViewController) as? BottomSheetAnimator
+        )
+        animator.reduceMotionOverride = isReduceMotionEnabled
         let context = MockAnimationContext(from: main, to: to)
         trackForMemoryLeaks(animator, file: file, line: line)
         trackForMemoryLeaks(context, file: file, line: line)
         return (animator, context)
+    }
+
+    func makeSheet(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> BottomSheetController {
+        let sheet = BottomSheetController(
+            title: "Bottom Sheet",
+            childView: UIView(),
+            appearance: BottomSheetController.Appearance(animationDuration: 0.0)
+        )
+        trackForMemoryLeaks(sheet)
+        return sheet
     }
 }

--- a/Tests/YBottomSheetTests/Animation/BottomSheetPresentAnimatorTests.swift
+++ b/Tests/YBottomSheetTests/Animation/BottomSheetPresentAnimatorTests.swift
@@ -11,11 +11,7 @@ import XCTest
 
 final class BottomSheetPresentAnimatorTests: XCTestCase {
     func test_animate() throws {
-        let sheetController = BottomSheetController(
-            title: "Bottom Sheet",
-            childView: UIView(),
-            appearance: BottomSheetController.Appearance(animationDuration: 0.0)
-        )
+        let sheetController = makeSheet()
         let (sut, context) = try makeSUT(sheetViewController: sheetController, to: sheetController)
 
         XCTAssertTrue(sut is BottomSheetPresentAnimator)
@@ -26,15 +22,42 @@ final class BottomSheetPresentAnimatorTests: XCTestCase {
         RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         XCTAssertTrue(context.wasCompleteCalled)
         XCTAssertTrue(context.didComplete)
+    }
+
+    func test_animateWithoutReduceMotion_TranslatesUp() throws {
+        let sheetController = makeSheet()
+        let (sut, context) = try makeSUT(
+            sheetViewController: sheetController,
+            to: sheetController,
+            isReduceMotionEnabled: false
+        )
+
+        sut.animateTransition(using: context)
+
+        // Wait for the run loop to tick (animate keyboard)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
         XCTAssertEqual(sheetController.dimmerView.alpha, 1)
         XCTAssertLessThan(sheetController.sheetView.frame.minY, context.containerView.bounds.maxY)
     }
 
-    func test_animateWithoutTo_Fails() throws {
-        let sheetController = BottomSheetController(
-            title: "Bottom Sheet",
-            childView: UIView()
+    func test_animateWithReduceMotion_FadesIn() throws {
+        let sheetController = makeSheet()
+        let (sut, context) = try makeSUT(
+            sheetViewController: sheetController,
+            to: sheetController,
+            isReduceMotionEnabled: true
         )
+
+        sut.animateTransition(using: context)
+
+        // Wait for the run loop to tick (animate keyboard)
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+        XCTAssertEqual(sheetController.dimmerView.alpha, 1)
+        XCTAssertEqual(sheetController.sheetView.alpha, 1)
+    }
+
+    func test_animateWithoutTo_Fails() throws {
+        let sheetController = makeSheet()
         let (sut, context) = try makeSUT(sheetViewController: sheetController, to: nil)
 
         XCTAssertFalse(context.wasCompleteCalled)
@@ -49,16 +72,35 @@ private extension BottomSheetPresentAnimatorTests {
     func makeSUT(
         sheetViewController: BottomSheetController,
         to: UIViewController?,
+        isReduceMotionEnabled: Bool? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws -> (UIViewControllerAnimatedTransitioning, MockAnimationContext) {
         let main = UIViewController()
         let animator = try XCTUnwrap(
-            sheetViewController.animationController(forPresented: sheetViewController, presenting: main, source: main)
+            sheetViewController.animationController(
+                forPresented: sheetViewController,
+                presenting: main,
+                source: main
+            ) as? BottomSheetAnimator
         )
+        animator.reduceMotionOverride = isReduceMotionEnabled
         let context = MockAnimationContext(from: main, to: to)
         trackForMemoryLeaks(animator, file: file, line: line)
         trackForMemoryLeaks(context, file: file, line: line)
         return (animator, context)
+    }
+
+    func makeSheet(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> BottomSheetController {
+        let sheet = BottomSheetController(
+            title: "Bottom Sheet",
+            childView: UIView(),
+            appearance: BottomSheetController.Appearance(animationDuration: 0.0)
+        )
+        trackForMemoryLeaks(sheet)
+        return sheet
     }
 }


### PR DESCRIPTION
## Introduction ##

When reduce motion accessibility feature is enabled we are fading the sheet in and out instead of sliding it on/off the bottom of the screen.

## Purpose ##

- Introduced reduce motion accessibility feature.
- Fix #6 

## Scope ##

we are disabling the sliding animation if reduce motion accessibility is enabled.

## 🎬 Video ##

![reduce motion](https://user-images.githubusercontent.com/102538361/227247678-c3bf6cea-8ced-4fde-aa7b-7caaf9915799.gif)



## 📈 Coverage ##

##### Code #####

<img width="1052" alt="Screenshot 2023-03-23 at 12 31 51 PM" src="https://user-images.githubusercontent.com/102538361/227128215-fa980149-351e-48a5-85d0-1353cc7a420f.png">


##### Documentation #####

<img width="753" alt="Screenshot 2023-03-23 at 12 36 03 PM" src="https://user-images.githubusercontent.com/102538361/227128493-b680d1a6-8390-4cf6-a187-e750379d9a1a.png">

