### PR TITLE
[Issue 16] Fix corner radius bug

### DIFF
--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -46,7 +46,6 @@ public class BottomSheetController: UIViewController {
         let view = UIView()
         view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         view.backgroundColor = .systemBackground
-        view.backgroundColor = .systemBackground
         return view
     }()
     /// Bottom sheet drag indicator view.
@@ -178,6 +177,16 @@ private extension BottomSheetController {
     func build(_ subview: UIView, title: String) {
         contentView.addSubview(subview)
         subview.constrainEdges()
+
+        if let backgroundColor = subview.backgroundColor,
+           backgroundColor.rgbaComponents.alpha == 1 {
+            // use the subview's background color for the sheet
+            sheetView.backgroundColor = backgroundColor
+            // but we have to set the subview's background to nil or else
+            // it will overflow the sheet and not be cropped by the corner radius.
+            subview.backgroundColor = nil
+        }
+
         indicatorView = DragIndicatorView(appearance: appearance.indicatorAppearance ?? .default)
         indicatorContainer.addSubview(indicatorView)
 

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -343,6 +343,51 @@ final class BottomSheetControllerTests: XCTestCase {
         sut.simulateTapCloseButton()
         XCTAssertTrue(sut.isDismissed)
     }
+
+    func test_backgroundColor_copiedFromChild() {
+        let color: UIColor = .systemPurple
+        let view = UIView()
+        view.backgroundColor = color
+        let sut = makeSUT(view: view)
+        let traits = UITraitCollection(preferredContentSizeCategory: .large)
+        XCTAssertNotNil(view.backgroundColor)
+
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(
+            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            color.resolvedColor(with: traits)
+        )
+        XCTAssertNil(view.backgroundColor)
+    }
+
+    func test_clearBackgroundColor_notCopiedFromChild() {
+        let view = UIView()
+        view.backgroundColor = .clear
+        let sut = makeSUT(view: view)
+        let traits = UITraitCollection(preferredContentSizeCategory: .large)
+
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(
+            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            UIColor.systemBackground.resolvedColor(with: traits)
+        )
+    }
+
+    func test_nilBackgroundColor_notCopiedFromChild() {
+        let view = UIView()
+        view.backgroundColor = nil
+        let sut = makeSUT(view: view)
+        let traits = UITraitCollection(preferredContentSizeCategory: .large)
+
+        sut.loadViewIfNeeded()
+
+        XCTAssertEqual(
+            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            UIColor.systemBackground.resolvedColor(with: traits)
+        )
+    }
 }
 
 private extension BottomSheetControllerTests {


### PR DESCRIPTION
## Introduction ##

The bottom sheet's corner radius doesn't show when the child view has a background color.

## Purpose ##

Fix #16 Corner radius should be visibly applied to the bottom sheet.

## Scope ##

* Changes to BottomSheetController
* Additional unit tests

## Discussion ##

We're also copying over the child view color and applying it to the sheet so that even the safe area of the sheet and the drag indicator / header area (if any) has a matching color

## 📱 Screenshots ##

| Before | After |
| --- | --- |
| ![bs_16_no_corner](https://user-images.githubusercontent.com/1037520/228292215-af95ddb0-9709-4e05-8e9c-77fd7d87f0cf.png) | ![bs_16_with_corner](https://user-images.githubusercontent.com/1037520/228292212-a38d6ba1-bdb7-4142-88b7-c820a6b247d3.png) |
| ![bs_16_resizable_before](https://user-images.githubusercontent.com/1037520/228292192-1e44cce6-f4b0-467c-acdf-03a6db0e917c.png) | ![bs_16_resizable_after](https://user-images.githubusercontent.com/1037520/228292203-0f656794-cb55-4c7c-9d8a-ce35cff79659.png) |

## 📈 Coverage ##

##### Code #####

100%
<img width="671" alt="image" src="https://user-images.githubusercontent.com/1037520/228292824-d4d219ab-33eb-413a-886f-977b0a8e9bd5.png">

##### Documentation #####

100%
<img width="603" alt="image" src="https://user-images.githubusercontent.com/1037520/228292648-9819e9b0-dadd-466d-a29f-c3656ff8ab46.png">
