### PR TITLE
[ISSUE] SwiftLint warning fixed

### DIFF
--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -12,8 +12,7 @@ import YMatterType
 @testable import YBottomSheet
 
 // OK to have lots of test cases
-// swiftlint:disable file_length
-// swiftlint:disable type_body_length
+// swiftlint:disable file_length type_body_length
 
 final class BottomSheetControllerTests: XCTestCase {
     var window: UIWindow!
@@ -486,3 +485,4 @@ final class MockPanGesture: UIPanGestureRecognizer {
     override func translation(in view: UIView?) -> CGPoint { translation }
     override func velocity(in view: UIView?) -> CGPoint { velocity }
 }
+// swiftlint:enable file_length type_body_length


### PR DESCRIPTION
## Introduction ##

SwiftLint 0.51.0 now requires us to manually re-enable all rules disabled on the file level.
## Purpose ##

To re-enable the silent warnings.
Fix https://github.com/yml-org/ybottomsheet-ios/issues/18
## Scope ##

Enabling the SwiftLint warnings.
## Out of Scope ##

No functionality or UI changes.

## 📈 Coverage ##

##### Code #####

100%
<img width="788" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/233339477-2678e81a-aff1-421a-a269-d7743a47b8bd.png">

##### Documentation #####

100%
<img width="565" alt="Jazzy report" src="https://user-images.githubusercontent.com/111066844/233339563-10c9d67d-6000-4ccd-a7cb-71ac2d23b9f0.png">
