### PR TITLE
[Issue-21] Expose minimumTopOffset

### DIFF
--- a/Sources/YBottomSheet/BottomSheetController+Appearance.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance.swift
@@ -32,7 +32,6 @@ extension BottomSheetController {
         ///
         /// The top of the sheet will not move beyond this gap from the top of the safe area.
         public var minimumTopOffset: CGFloat
-        /// Whether the sheet can be dismissed by swiping down or tapping on the dimmer. Default is `true`.
         /// (Optional) Minimum content view height. Default is `nil`.
         ///
         /// Only applicable for resizable sheets. `nil` means to use the content view's intrinsic height as the minimum.

--- a/Sources/YBottomSheet/BottomSheetController+Appearance.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance.swift
@@ -28,6 +28,11 @@ extension BottomSheetController {
         public var presentAnimationCurve: UIView.AnimationOptions
         /// Animation type during dismissing. Default is `curveEaseOut`.
         public var dismissAnimationCurve: UIView.AnimationOptions
+        /// Minimum top offset of sheet from safe area top. Default is `44`.
+        ///
+        /// The top of the sheet will not move beyond this gap from the top of the safe area.
+        public var minimumTopOffset: CGFloat
+        /// Whether the sheet can be dismissed by swiping down or tapping on the dimmer. Default is `true`.
         /// (Optional) Minimum content view height. Default is `nil`.
         ///
         /// Only applicable for resizable sheets. `nil` means to use the content view's intrinsic height as the minimum.
@@ -44,16 +49,17 @@ extension BottomSheetController {
 
         /// Initializes an `Appearance`.
         /// - Parameters:
-        ///   - indicatorAppearance: Appearance of the drag indicator or pass `nil` to hide.
-        ///   - headerAppearance: Appearance of the sheet header view or pass `nil` to hide.
-        ///   - layout: Bottom sheet layout properties such as corner radius.
-        ///   - elevation: Bottom sheet's shadow or pass `nil` to hide
-        ///   - dimmerColor: Dimmer view color or pass `nil` to hide.
-        ///   - animationDuration: Animation duration for bottom sheet. Default is `0.3`.
-        ///   - presentAnimationCurve: Animaiton during presenting.
-        ///   - dismissAnimationCurve: Animation during dismiss.
-        ///   - minimumContentHeight: Optional) Minimum content view height.
-        ///   - isDismissAllowed: Whether the sheet can be dismissed by swiping down or tapping on the dimmer.
+        ///   - indicatorAppearance: appearance of the drag indicator or pass `nil` to hide.
+        ///   - headerAppearance: appearance of the sheet header view or pass `nil` to hide.
+        ///   - layout: bottom sheet layout properties such as corner radius.
+        ///   - elevation: bottom sheet's shadow or pass `nil` to hide
+        ///   - dimmerColor: dimmer view color or pass `nil` to hide.
+        ///   - animationDuration: animation duration for bottom sheet. Default is `0.3`.
+        ///   - presentAnimationCurve: animation type during presenting.
+        ///   - dismissAnimationCurve: animation type during dismiss.
+        ///   - minimumTopOffset: minimum top offset. Default is `44`
+        ///   - minimumContentHeight: (optional) minimum content view height.
+        ///   - isDismissAllowed: whether the sheet can be dismissed by swiping down or tapping on the dimmer.
         public init(
             indicatorAppearance: DragIndicatorView.Appearance? = nil,
             headerAppearance: SheetHeaderView.Appearance? = .default,
@@ -63,6 +69,7 @@ extension BottomSheetController {
             animationDuration: TimeInterval = 0.3,
             presentAnimationCurve: UIView.AnimationOptions = .curveEaseIn,
             dismissAnimationCurve: UIView.AnimationOptions = .curveEaseOut,
+            minimumTopOffset: CGFloat = 44,
             minimumContentHeight: CGFloat? = nil,
             isDismissAllowed: Bool = true
         ) {
@@ -74,6 +81,7 @@ extension BottomSheetController {
             self.animationDuration = animationDuration
             self.presentAnimationCurve = presentAnimationCurve
             self.dismissAnimationCurve = dismissAnimationCurve
+            self.minimumTopOffset = minimumTopOffset
             self.minimumContentHeight = minimumContentHeight
             self.isDismissAllowed = isDismissAllowed
         }

--- a/Sources/YBottomSheet/BottomSheetController+build.swift
+++ b/Sources/YBottomSheet/BottomSheetController+build.swift
@@ -1,0 +1,94 @@
+//
+//  BottomSheetController+build.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 4/26/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+internal extension BottomSheetController {
+    func build() {
+        switch content {
+        case .view(title: let title, view: let childView):
+            build(childView, title: title)
+        case .controller(let childController):
+            build(childController)
+        }
+    }
+}
+
+private extension BottomSheetController {
+    func build(_ subview: UIView, title: String) {
+        contentView.addSubview(subview)
+        subview.constrainEdges()
+
+        if let backgroundColor = subview.backgroundColor,
+           backgroundColor.rgbaComponents.alpha == 1 {
+            // use the subview's background color for the sheet
+            sheetView.backgroundColor = backgroundColor
+            // but we have to set the subview's background to nil or else
+            // it will overflow the sheet and not be cropped by the corner radius.
+            subview.backgroundColor = nil
+        }
+
+        indicatorView = DragIndicatorView(appearance: appearance.indicatorAppearance ?? .default)
+        indicatorContainer.addSubview(indicatorView)
+
+        headerView = SheetHeaderView(title: title, appearance: appearance.headerAppearance ?? .default)
+        headerView.delegate = self
+        buildSheet()
+    }
+
+    func build(_ childController: UIViewController) {
+        addChild(childController)
+        build(childController.view, title: childController.title ?? "")
+        childController.didMove(toParent: self)
+    }
+
+    func buildSheet() {
+        buildViews()
+        buildConstraints()
+        updateViewAppearance()
+        addGestures()
+    }
+
+    func buildViews() {
+        view.addSubview(dimmerView)
+        view.addSubview(dimmerTapView)
+        view.addSubview(sheetView)
+        sheetView.addSubview(stackView)
+        stackView.addArrangedSubview(indicatorContainer)
+        stackView.addArrangedSubview(headerView)
+        stackView.addArrangedSubview(contentView)
+    }
+
+    func buildConstraints() {
+        dimmerView.constrainEdges()
+        dimmerTapView.constrainEdges(.notBottom)
+        dimmerTapView.constrain(.bottomAnchor, to: sheetView.topAnchor)
+
+        sheetView.constrainEdges(.notTop)
+        minimumTopOffsetAnchor = sheetView.constrain(
+            .topAnchor,
+            to: view.safeAreaLayoutGuide.topAnchor,
+            relatedBy: .greaterThanOrEqual
+        )
+
+        indicatorView.constrain(.bottomAnchor, to: indicatorContainer.bottomAnchor)
+        indicatorTopAnchor = indicatorView.constrain(
+            .topAnchor,
+            to: indicatorContainer.topAnchor
+        )
+        indicatorView.constrainCenter(.x)
+
+        stackView.constrain(.topAnchor, to: sheetView.topAnchor)
+        stackView.constrainEdges(.horizontal, to: view.safeAreaLayoutGuide)
+        stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide, relatedBy: .greaterThanOrEqual)
+        stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide, priority: Priorities.sheetContentHugging)
+
+        contentView.constrainEdges(.horizontal)
+        headerView.constrainEdges(.horizontal)
+    }
+}

--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -119,8 +119,11 @@ public class BottomSheetController: UIViewController {
     }
     
     /// :nodoc:
-    internal required init?(coder: NSCoder) { nil }
-    
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) is not available for BottomSheetController")
+    }
+
     /// :nodoc:
     public override func viewDidLoad() {
         super.viewDidLoad()

--- a/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView.swift
+++ b/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView.swift
@@ -34,7 +34,10 @@ open class DragIndicatorView: UIView {
     }
     
     /// :nodoc:
-    required public init?(coder: NSCoder) { nil }
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) is not available for DragIndicatorView")
+    }
 }
 
 private extension DragIndicatorView {

--- a/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
+++ b/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
@@ -48,8 +48,11 @@ open class SheetHeaderView: UIView {
     }
     
     /// :nodoc:
-    required public init?(coder: NSCoder) { nil }
-    
+    @available(*, unavailable)
+    required public init?(coder: NSCoder) {
+        fatalError("init(coder:) is not available for SheetHeaderView")
+    }
+
     @objc private func closeButtonAction() {
         delegate?.didTapCloseButton()
     }

--- a/Tests/YBottomSheetTests/Animation/BottomSheetAnimatorTests.swift
+++ b/Tests/YBottomSheetTests/Animation/BottomSheetAnimatorTests.swift
@@ -46,7 +46,7 @@ private extension BottomSheetAnimatorTests {
         line: UInt = #line
     ) -> BottomSheetAnimator {
         let sut = BottomSheetAnimator(sheetViewController: sheetViewController)
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 }

--- a/Tests/YBottomSheetTests/Animation/BottomSheetDismissAnimatorTests.swift
+++ b/Tests/YBottomSheetTests/Animation/BottomSheetDismissAnimatorTests.swift
@@ -84,8 +84,8 @@ private extension BottomSheetDismissAnimatorTests {
         )
         animator.reduceMotionOverride = isReduceMotionEnabled
         let context = MockAnimationContext(from: main, to: to)
-        trackForMemoryLeaks(animator, file: file, line: line)
-        trackForMemoryLeaks(context, file: file, line: line)
+        trackForMemoryLeak(animator, file: file, line: line)
+        trackForMemoryLeak(context, file: file, line: line)
         return (animator, context)
     }
 
@@ -98,7 +98,7 @@ private extension BottomSheetDismissAnimatorTests {
             childView: UIView(),
             appearance: BottomSheetController.Appearance(animationDuration: 0.0)
         )
-        trackForMemoryLeaks(sheet)
+        trackForMemoryLeak(sheet)
         return sheet
     }
 }

--- a/Tests/YBottomSheetTests/Animation/BottomSheetPresentAnimatorTests.swift
+++ b/Tests/YBottomSheetTests/Animation/BottomSheetPresentAnimatorTests.swift
@@ -86,8 +86,8 @@ private extension BottomSheetPresentAnimatorTests {
         )
         animator.reduceMotionOverride = isReduceMotionEnabled
         let context = MockAnimationContext(from: main, to: to)
-        trackForMemoryLeaks(animator, file: file, line: line)
-        trackForMemoryLeaks(context, file: file, line: line)
+        trackForMemoryLeak(animator, file: file, line: line)
+        trackForMemoryLeak(context, file: file, line: line)
         return (animator, context)
     }
 
@@ -100,7 +100,7 @@ private extension BottomSheetPresentAnimatorTests {
             childView: UIView(),
             appearance: BottomSheetController.Appearance(animationDuration: 0.0)
         )
-        trackForMemoryLeaks(sheet)
+        trackForMemoryLeak(sheet)
         return sheet
     }
 }

--- a/Tests/YBottomSheetTests/BottomSheetControllerAppearanceTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerAppearanceTests.swift
@@ -11,10 +11,19 @@ import YMatterType
 @testable import YBottomSheet
 
 final class BottomSheetControllerAppearanceTests: XCTestCase {
-    func test_init_propertiesDefaultValue() {
+    func test_init_propertiesDefaultValue() throws {
         let sut = BottomSheetController.Appearance.default
+        XCTAssertNil(sut.indicatorAppearance)
+        let headerAppearance = try XCTUnwrap(sut.headerAppearance)
+        XCTAssertHeaderAppearanceEqual(headerAppearance, .default)
         XCTAssertEqual(sut.layout, .default)
         XCTAssertEqual(sut.elevation, nil)
         XCTAssertEqual(sut.dimmerColor, .black.withAlphaComponent(0.5))
+        XCTAssertEqual(sut.animationDuration, 0.3)
+        XCTAssertEqual(sut.presentAnimationCurve, .curveEaseIn)
+        XCTAssertEqual(sut.dismissAnimationCurve, .curveEaseOut)
+        XCTAssertEqual(sut.minimumTopOffset, 44)
+        XCTAssertNil(sut.minimumContentHeight)
+        XCTAssertTrue(sut.isDismissAllowed)
     }
 }

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -27,11 +27,6 @@ final class BottomSheetControllerTests: XCTestCase {
         super.tearDown()
     }
     
-    func test_initWithCoder() throws {
-        let sut = BottomSheetController(coder: try makeCoder(for: UIView()))
-        XCTAssertNil(sut)
-    }
-    
     func test_init_withViewControllerAsContentView() {
         let vc = UIViewController()
         vc.title = "Bottom Sheet"
@@ -419,11 +414,6 @@ private extension BottomSheetControllerTests {
          )
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    func makeCoder(for view: UIView) throws -> NSCoder {
-        let data = try NSKeyedArchiver.archivedData(withRootObject: view, requiringSecureCoding: false)
-        return try NSKeyedUnarchiver(forReadingFrom: data)
     }
 }
 

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -31,13 +31,33 @@ final class BottomSheetControllerTests: XCTestCase {
         let vc = UIViewController()
         vc.title = "Bottom Sheet"
         let sut = makeSUT(viewController: vc)
-        XCTAssertNotNil(sut)
+        sut.loadViewIfNeeded()
+        
+        XCTAssertTrue(sut.contentView.subviews.contains(vc.view))
+        XCTAssertEqual(vc.parent, sut)
+        XCTAssertFalse(sut.children.isEmpty)
     }
     
     func test_init_withViewAsContentView() {
         let view = UIView()
         let sut = makeSUT(view: view, headerTitle: "Bottom Sheet")
-        XCTAssertNotNil(sut)
+        sut.loadViewIfNeeded()
+
+        XCTAssertTrue(sut.contentView.subviews.contains(view))
+        XCTAssertTrue(sut.children.isEmpty)
+    }
+
+    func test_viewDidAppear_setsVOFocus() {
+        // Given
+        let sut = SpyBottomSheetController(childController: UIViewController())
+        XCTAssertFalse(sut.voiceOverFocusSet)
+
+        // When (simulate view controller appearance)
+        sut.beginAppearanceTransition(true, animated: false)
+        sut.endAppearanceTransition()
+
+        // Then
+        XCTAssertTrue(sut.voiceOverFocusSet)
     }
     
     func test_init_withRandomValues() {
@@ -243,6 +263,28 @@ final class BottomSheetControllerTests: XCTestCase {
         XCTAssertEqual(sut.lastYOffset, offset)
     }
 
+    func test_draggingDown_doesNotResizeViewBelowMinimumContentSize() {
+        let sut = SpyBottomSheetController(title: "", childView: MiniView(), appearance: .defaultResizable)
+        sut.minimumContentHeight = CGFloat(Int.random(in: 32...128))
+        sut.loadViewIfNeeded()
+
+        let gesture = MockPanGesture()
+        gesture.state = .began
+        sut.simulateDragging(gesture)
+        let offset = sut.lastYOffset
+
+        gesture.state = .changed
+        let panDistance = CGFloat(Int.random(in: 20...100))
+        gesture.translation = CGPoint(x: 0, y: panDistance)
+        sut.simulateDragging(gesture)
+
+        gesture.state = .ended
+        sut.simulateDragging(gesture)
+        XCTAssertEqual(sut.lastYOffset, offset)
+        let chromeHeight = sut.indicatorContainer.bounds.height + (sut.headerView?.bounds.height ?? 0)
+        XCTAssertEqual(sut.view.bounds.height, offset + sut.minimumContentHeight + chromeHeight)
+    }
+
     func test_performEscape_dismissesSheet() {
         let sut = SpyBottomSheetController(childController: UIViewController())
         XCTAssertFalse(sut.isDismissed)
@@ -422,6 +464,7 @@ final class SpyBottomSheetController: BottomSheetController {
     var onSwipeDown = false
     var onDimmerTapped = false
     var onDragging = false
+    var voiceOverFocusSet = false
     
     override func simulateTapCloseButton() {
         super.simulateTapCloseButton()
@@ -449,6 +492,11 @@ final class SpyBottomSheetController: BottomSheetController {
         }
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        voiceOverFocusSet = true
+    }
+
     @discardableResult
     override func simulateDragging(_ gesture: UIPanGestureRecognizer) -> Bool {
         guard super.simulateDragging(gesture) == true else { return false }
@@ -466,6 +514,10 @@ final class SpyBottomSheetController: BottomSheetController {
 
 final class ChildView: UIView {
     override var intrinsicContentSize: CGSize { CGSize(width: 300, height: 300) }
+}
+
+final class MiniView: UIView {
+    override var intrinsicContentSize: CGSize { CGSize(width: 300, height: 16) }
 }
 
 final class MockPanGesture: UIPanGestureRecognizer {

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -438,7 +438,7 @@ private extension BottomSheetControllerTests {
             childController: viewController,
             appearance: appearance
         )
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
     
@@ -454,7 +454,7 @@ private extension BottomSheetControllerTests {
             childView: view,
             appearance: appearance
          )
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 }

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
@@ -10,12 +10,6 @@ import XCTest
 @testable import YBottomSheet
 
 final class DragIndicatorViewTests: XCTestCase {
-    func test_initWithCoder() throws {
-        let dragIndicatorView = DragIndicatorView()
-        let sut = DragIndicatorView(coder: try makeCoder(for: dragIndicatorView))
-        XCTAssertNil(sut)
-    }
-    
     func test_init_withDefaultValues() {
         let sut = makeSUT()
         XCTAssertNotNil(sut)
@@ -84,10 +78,5 @@ private extension DragIndicatorViewTests {
         let sut = DragIndicatorView(appearance: appearance)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    func makeCoder(for view: UIView) throws -> NSCoder {
-        let data = try NSKeyedArchiver.archivedData(withRootObject: view, requiringSecureCoding: false)
-        return try NSKeyedUnarchiver(forReadingFrom: data)
     }
 }

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorViewTests.swift
@@ -76,7 +76,7 @@ private extension DragIndicatorViewTests {
         line: UInt = #line
     ) -> DragIndicatorView {
         let sut = DragIndicatorView(appearance: appearance)
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 }

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewAppearanceTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewAppearanceTests.swift
@@ -13,11 +13,25 @@ import YMatterType
 final class SheetHeaderViewAppearanceTests: XCTestCase {
     func test_init_propertiesDefaultValue() {
         let sut = SheetHeaderView.Appearance.default
-        XCTAssertEqual(sut.title.textColor, .label)
-        XCTAssertEqual(sut.title.typography.fontFamily.familyName, Typography.systemFamily.familyName)
-        XCTAssertEqual(sut.title.typography.fontSize, UIFont.labelFontSize)
-        XCTAssertEqual(sut.title.typography.fontWeight, .semibold)
-        XCTAssertEqual(sut.closeButtonImage, UIImage(systemName: "xmark"))
-        XCTAssertEqual(sut.layout, SheetHeaderView.Appearance.Layout.default)
+        let expected = SheetHeaderView.Appearance(
+            title: (.label, .systemLabel.fontWeight(.semibold)),
+            closeButtonImage: UIImage(systemName: "xmark"),
+            layout: .default
+        )
+        
+        XCTAssertHeaderAppearanceEqual(sut, expected)
+    }
+}
+
+extension XCTestCase {
+    /// Compares two sheet header view appearances and asserts if they are not equal.
+    /// - Parameters:
+    ///   - lhs: the first appearance to compare
+    ///   - rh2: the second appearance to compare
+    func XCTAssertHeaderAppearanceEqual(_ lhs: SheetHeaderView.Appearance, _ rhs: SheetHeaderView.Appearance) {
+        XCTAssertEqual(lhs.title.textColor, rhs.title.textColor)
+        XCTAssertTypographyEqual(lhs.title.typography, rhs.title.typography)
+        XCTAssertEqual(lhs.closeButtonImage, rhs.closeButtonImage)
+        XCTAssertEqual(lhs.layout, rhs.layout)
     }
 }

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
@@ -15,15 +15,14 @@ final class SheetHeaderViewTests: XCTestCase {
     
     func test_init_withDefaultValues() {
         let sut = makeSUT()
-        XCTAssertNotNil(sut)
-        XCTAssertEqual(sut.titleLabel.typography.fontFamily.familyName, Typography.systemFamily.familyName)
-        XCTAssertEqual(sut.titleLabel.typography.fontSize, UIFont.labelFontSize)
-        XCTAssertEqual(sut.titleLabel.typography.fontWeight, .semibold)
-        XCTAssertEqual(sut.closeButton.isEnabled, true)
+
+        XCTAssertEqual(sut.titleLabel.textColor, .label)
+        XCTAssertTypographyEqual(sut.titleLabel.typography, .systemLabel.fontWeight(.semibold))
+        XCTAssertEqual(sut.closeButton.isHidden, false)
         XCTAssertEqual(sut.titleLabel.text, "")
     }
     
-    func test_init_withRandomValues() {
+    func test_init_withCustomValues() {
         let headerTitle = "Bottom Sheet"
         let appearance = SheetHeaderView.Appearance(
             title: (.red, .systemButton.bold),
@@ -31,27 +30,31 @@ final class SheetHeaderViewTests: XCTestCase {
             layout: .default
         )
         let sut = makeSUT(appearance: appearance, headerTitle: headerTitle)
-        XCTAssertNotNil(sut)
+
+        XCTAssertEqual(sut.titleLabel.textColor, .red)
+        XCTAssertTypographyEqual(sut.titleLabel.typography, .systemButton.bold)
         XCTAssertEqual(sut.titleLabel.typography.fontFamily.familyName, Typography.systemFamily.familyName)
         XCTAssertEqual(sut.titleLabel.typography.fontSize, UIFont.buttonFontSize)
         XCTAssertEqual(sut.titleLabel.typography.fontWeight, .bold)
-        XCTAssertEqual(sut.closeButton.isEnabled, true)
+        XCTAssertEqual(sut.closeButton.isHidden, true)
         XCTAssertEqual(sut.titleLabel.text, headerTitle)
     }
     
-    func test_changeHeaderViewTitleColor() {
+    func test_changeHeaderViewAppearance() {
         let sut = makeSUT()
         let color: UIColor = .red
         
         XCTAssertNotEqual(sut.titleLabel.textColor, color)
-        
+        XCTAssertTypographyEqual(sut.titleLabel.typography, .systemLabel.fontWeight(.semibold))
+
         sut.appearance = SheetHeaderView.Appearance(
-            title: (color, .systemButton.bold),
+            title: (color, .smallSystem.bold),
             closeButtonImage: nil,
             layout: .default
         )
         
         XCTAssertEqual(sut.titleLabel.textColor, color)
+        XCTAssertTypographyEqual(sut.titleLabel.typography, .smallSystem.bold)
     }
     
     func test_closeButtonAction() {

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
@@ -13,12 +13,6 @@ import YMatterType
 final class SheetHeaderViewTests: XCTestCase {
     var isDismissed = false
     
-    func test_initWithCoder() throws {
-        let sheetHeaderView = SheetHeaderView(title: "Bottom Sheet")
-        let sut = SheetHeaderView(coder: try makeCoder(for: sheetHeaderView))
-        XCTAssertNil(sut)
-    }
-    
     func test_init_withDefaultValues() {
         let sut = makeSUT()
         XCTAssertNotNil(sut)
@@ -82,11 +76,6 @@ private extension SheetHeaderViewTests {
         let sut = SheetHeaderView(title: headerTitle, appearance: appearance)
         trackForMemoryLeaks(sut, file: file, line: line)
         return sut
-    }
-    
-    func makeCoder(for view: UIView) throws -> NSCoder {
-        let data = try NSKeyedArchiver.archivedData(withRootObject: view, requiringSecureCoding: false)
-        return try NSKeyedUnarchiver(forReadingFrom: data)
     }
 }
 

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewTests.swift
@@ -77,7 +77,7 @@ private extension SheetHeaderViewTests {
         line: UInt = #line
     ) -> SheetHeaderView {
         let sut = SheetHeaderView(title: headerTitle, appearance: appearance)
-        trackForMemoryLeaks(sut, file: file, line: line)
+        trackForMemoryLeak(sut, file: file, line: line)
         return sut
     }
 }

--- a/Tests/YBottomSheetTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/YBottomSheetTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
@@ -2,14 +2,14 @@
 //  XCTestCase+MemoryLeakTracking.swift
 //  YBottomSheet
 //
-//  Created by Dev Karan on 10/01/23.
+//  Created by Karthik K Manoj on 07/20/22.
 //  Copyright © 2023 Y Media Labs. All rights reserved.
 //
 
 import XCTest
 
 extension XCTestCase {
-    func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+    func trackForMemoryLeak(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
         addTeardownBlock { [weak instance] in
             XCTAssertNil(
                 instance,

--- a/Tests/YBottomSheetTests/Test Helpers/XCTestCase+TypographyEquatable.swift
+++ b/Tests/YBottomSheetTests/Test Helpers/XCTestCase+TypographyEquatable.swift
@@ -1,0 +1,35 @@
+//
+//  XCTestCase+TypographyEquatable.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 3/21/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+import YMatterType
+
+extension XCTestCase {
+    /// Compares two typographies and asserts if they are not equal.
+    ///
+    /// `Typography` does not conform to `Equatable` because `fontFamily` is just a protocol
+    /// that is itself not `Equatable`. We can however compare some properties of `FontFamily` as
+    /// well as all the other properties of `Typography`.
+    /// - Parameters:
+    ///   - lhs: the first typography to compare
+    ///   - rh2: the second typography to compare
+    func XCTAssertTypographyEqual(_ lhs: Typography, _ rh2: Typography) {
+        XCTAssertEqual(lhs.fontFamily.familyName, rh2.fontFamily.familyName)
+        XCTAssertEqual(lhs.fontFamily.fontNameSuffix, rh2.fontFamily.fontNameSuffix)
+        XCTAssertEqual(lhs.fontFamily.supportedWeights, rh2.fontFamily.supportedWeights)
+        XCTAssertEqual(lhs.fontWeight, rh2.fontWeight)
+        XCTAssertEqual(lhs.fontSize, rh2.fontSize)
+        XCTAssertEqual(lhs.lineHeight, rh2.lineHeight)
+        XCTAssertEqual(lhs.letterSpacing, rh2.letterSpacing)
+        XCTAssertEqual(lhs.paragraphIndent, rh2.paragraphIndent)
+        XCTAssertEqual(lhs.paragraphSpacing, rh2.paragraphSpacing)
+        XCTAssertEqual(lhs.textDecoration, rh2.textDecoration)
+        XCTAssertEqual(lhs.textStyle, rh2.textStyle)
+        XCTAssertEqual(lhs.isFixed, rh2.isFixed)
+    }
+}


### PR DESCRIPTION
## Introduction ##

PWC may need fine-tuned control over the maximum size of bottom sheets. We had a private constant that controlled this, but now it's a public variable that's part of the sheet's appearance.

## Purpose ##

Fix #21 Move the private minimumTopOffset constant from BottomSheetController to Appearance and make it a public variable.

## Scope ##

* Move the minimumTopOffset property
* Make BottomSheetController.minimumContentHeight public
* Refactor BottomSheetController to better organize the code

## Discussion ##

The issue says to also move minimumContentHeight to Appearance, but it is already there serving a related but slightly different purpose, so I just switched it from `private let` to `public var` in BottomSheetController.

There are also a few cleanup items I did:
1. mark the `init(coder:)` methods as unavailable and removed their unit tests
2. added a helper file to tests for comparing Typography equality
3. improved the unit tests around the appearance
4. renamed memory leak tracking method for consistency

## 📱 Screenshots ##

Sheet appearance is unchanged.

## 📈 Coverage ##

##### Code #####

100%

<img width="700" alt="image" src="https://user-images.githubusercontent.com/1037520/234577073-7a085d00-a144-4990-922b-135e2e7b3029.png">

##### Documentation #####

100%

<img width="615" alt="image" src="https://user-images.githubusercontent.com/1037520/234577348-6ec0867c-aad0-446b-9a84-7bcf5fbcfdb6.png">
