### PR TITLE
[Issue 19] Use SystemImage enum for default close button image

### DIFF
--- a/Sources/YBottomSheet/Enums/BottomSheetController+Enums.swift
+++ b/Sources/YBottomSheet/Enums/BottomSheetController+Enums.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2023 Y Media Labs. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 internal extension BottomSheetController {

--- a/Sources/YBottomSheet/Enums/BottomSheetController+Images.swift
+++ b/Sources/YBottomSheet/Enums/BottomSheetController+Images.swift
@@ -1,0 +1,20 @@
+//
+//  BottomSheetController+Images.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 4/26/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+import YCoreUI
+
+extension BottomSheetController {
+    /// Images
+    enum Images: String, SystemImage, CaseIterable {
+        /// xmark
+        case xmark
+        
+        static var renderingMode: UIImage.RenderingMode { .alwaysTemplate }
+    }
+}

--- a/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView+Appearance.swift
+++ b/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView+Appearance.swift
@@ -20,9 +20,12 @@ extension SheetHeaderView {
         /// Header view layout properties such as spacing between views. Default is `.default`.
         public let layout: Layout
         
-        /// Default appearance.
+        /// Default appearance
         public static let `default` = Appearance()
-                
+
+        /// Default close button image (SF symbol `xmark`)
+        public static let defaultCloseButtonImage: UIImage = BottomSheetController.Images.xmark.image
+
         /// Initializes a sheet header appearance.
         /// - Parameters:
         ///   - title: tuple consisting of `textColor` and `typography` for the title label.
@@ -30,7 +33,7 @@ extension SheetHeaderView {
         ///   - layout: sheet header view layout properties such as spacing between views.
         public init(
             title: (textColor: UIColor, typography: Typography) = (.label, .systemLabel.fontWeight(.semibold)),
-            closeButtonImage: UIImage? = UIImage(systemName: "xmark"),
+            closeButtonImage: UIImage? = defaultCloseButtonImage,
             layout: Layout = .default
         ) {
             self.title = title

--- a/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
+++ b/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView.swift
@@ -26,8 +26,14 @@ open class SheetHeaderView: UIView {
     public let titleLabel = TypographyLabel(typography: .systemLabel.fontWeight(.semibold))
     
     /// Close button to dismiss the bottom sheet.
-    public let closeButton = UIButton()
-    
+    public let closeButton: UIButton = {
+        let button = UIButton()
+        button.adjustsImageSizeForAccessibilityContentSizeCategory = true
+        button.imageView?.contentMode = .scaleAspectFit
+        button.imageView?.constrainAspectRatio(1)
+        return button
+    }()
+
     private let buttonSize = CGSize(width: 44, height: 44)
     private weak var closeButtonLeadingConstraint: NSLayoutConstraint?
     private weak var closeButtonTrailingConstraint: NSLayoutConstraint?

--- a/Tests/YBottomSheetTests/Enums/BottomSheetController+ImagesTests.swift
+++ b/Tests/YBottomSheetTests/Enums/BottomSheetController+ImagesTests.swift
@@ -1,0 +1,18 @@
+//
+//  BottomSheetController+ImagesTests.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 4/26/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YBottomSheet
+
+final class BottomSheetControllerImagesTests: XCTestCase {
+    func test_loadImages() {
+        BottomSheetController.Images.allCases.forEach {
+            XCTAssertNotNil($0.loadImage())
+        }
+    }
+}

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewAppearanceTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderViewAppearanceTests.swift
@@ -15,11 +15,16 @@ final class SheetHeaderViewAppearanceTests: XCTestCase {
         let sut = SheetHeaderView.Appearance.default
         let expected = SheetHeaderView.Appearance(
             title: (.label, .systemLabel.fontWeight(.semibold)),
-            closeButtonImage: UIImage(systemName: "xmark"),
+            closeButtonImage: SheetHeaderView.Appearance.defaultCloseButtonImage,
             layout: .default
         )
         
         XCTAssertHeaderAppearanceEqual(sut, expected)
+    }
+
+    func test_defaultCloseButtonImage() {
+        let sut = SheetHeaderView.Appearance.defaultCloseButtonImage
+        XCTAssertEqual(sut, BottomSheetController.Images.xmark.image)
     }
 }
 


### PR DESCRIPTION
## Introduction ##

We'd like to update the bottom sheet to leverage the `SystemImage` protocol for loading the default close button image. This matches work we've done on our Y—Tags and Y—Stepper repos.

## Purpose ##

Fix #19 Load the default close button image (an "X" from SF Symbols) using `SystemImage`.

## Scope ##

* Add new Images enum that conforms to `SystemImage`
* Update `SheetHeaderView.Appearance`
* Add / Update unit tests

## Discussion ##

This change also makes the default close button image resize with Dynamic Type (and Accessibility Bold Text).

## 🎬 Video ##

| Before | After |
| --- | --- |
|  ![bs_19_before](https://user-images.githubusercontent.com/1037520/234798000-0dfeb25d-8373-4324-a8fd-915cf5d8ac9d.gif) | ![bs_19_after](https://user-images.githubusercontent.com/1037520/234798031-22412d36-71e8-4239-8fa0-ace47e52c6b0.gif) |

## 📈 Coverage ##

##### Code #####

100%

<img width="679" alt="image" src="https://user-images.githubusercontent.com/1037520/234801851-c14a9896-b16b-4c44-8c61-dbdbe63fd576.png">

##### Documentation #####

100%

<img width="636" alt="image" src="https://user-images.githubusercontent.com/1037520/234801586-3dfd1271-0722-41ad-acf3-6a2a29235fd6.png">
