### PR TITLE
[Issue 22] Fix bottom sheet height for navigation and table controllers

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/YBottomSheet.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/YBottomSheet.xcscheme
@@ -58,7 +58,8 @@
       codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "YBottomSheetTests"

--- a/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
@@ -30,6 +30,7 @@ class BottomSheetPresentAnimator: BottomSheetAnimator {
             sheet.sheetView.frame = sheetFrame
             // lay out sheet's subviews prior to first appearance
             sheet.sheetView.layoutIfNeeded()
+            sheet.updateShadow()
             sheet.view.setNeedsLayout()
         }
         

--- a/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
+++ b/Sources/YBottomSheet/Animation/BottomSheetPresentAnimator.swift
@@ -28,6 +28,8 @@ class BottomSheetPresentAnimator: BottomSheetAnimator {
             var sheetFrame = sheet.sheetView.frame
             sheetFrame.origin.y = toFinalFrame.maxY + (sheet.appearance.elevation?.extent.top ?? 0)
             sheet.sheetView.frame = sheetFrame
+            // lay out sheet's subviews prior to first appearance
+            sheet.sheetView.layoutIfNeeded()
             sheet.view.setNeedsLayout()
         }
         

--- a/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
@@ -13,15 +13,57 @@ extension BottomSheetController.Appearance {
     public struct Layout: Equatable {
         /// Corner radius of bottom sheet view. Default is `16`.
         public var cornerRadius: CGFloat
-        
+
+        /// Minimum top offset of sheet from safe area top. Default is `44`.
+        ///
+        /// The top of the sheet will not move beyond this gap from the top of the safe area.
+        public var minimumTopOffset: CGFloat
+
+        /// Maximum content height of sheet.
+        ///
+        /// Only applicable for resizable sheets.
+        /// If `nil` a resizable sheet will be allowed to grow until it nearly fills the screen.
+        /// c.f. `minimumTopOffset`
+        public var maximumContentHeight: CGFloat?
+
+        /// Ideal content height of sheet.
+        ///
+        /// Used to determine the initial size of the sheet.
+        /// If `nil`, the content's `instrinsicContentHeight` will be used.
+        public var idealContentHeight: CGFloat?
+
+        /// Minimum content height of sheet.
+        ///
+        /// Only applicable for resizable sheets.
+        /// A resizable sheet will not be allowed to shrink its content below this value.
+        public var minimumContentHeight: CGFloat
+
         /// Default layout.
         public static let `default` = Layout(cornerRadius: 16)
-        
+
         /// Initializes a sheet layout.
         /// - Parameters:
         ///   - cornerRadius: corner radius of bottom sheet view.
-        public init(cornerRadius: CGFloat) {
+
+        // Initializes a bottom sheet layout.
+        /// - Parameters:
+        ///   - cornerRadius: corner radius of bottom sheet view.
+        ///   - minimumTopOffset: minimum top offset. Default is `44`.
+        ///   - maximumContentHeight: maximum content height of sheet. Default is `nil`.
+        ///   - idealContentHeight: ideal content height of sheet. Default is `nil`.
+        ///   - minimumContentHeight: minimum content height of sheet. Default is `88`.
+        public init(
+            cornerRadius: CGFloat,
+            minimumTopOffset: CGFloat = 44,
+            maximumContentHeight: CGFloat? = nil,
+            idealContentHeight: CGFloat? = nil,
+            minimumContentHeight: CGFloat = 88
+        ) {
             self.cornerRadius = cornerRadius
+            self.minimumTopOffset = minimumTopOffset
+            self.maximumContentHeight = maximumContentHeight
+            self.idealContentHeight = idealContentHeight
+            self.minimumContentHeight = minimumContentHeight
         }
     }
 }

--- a/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
@@ -1,5 +1,5 @@
 //
-//  BottomSheetController.Appearance+Layout.swift
+//  BottomSheetController+Appearance+Layout.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 19/01/23.

--- a/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance+Layout.swift
@@ -39,21 +39,17 @@ extension BottomSheetController.Appearance {
         public var minimumContentHeight: CGFloat
 
         /// Default layout.
-        public static let `default` = Layout(cornerRadius: 16)
-
-        /// Initializes a sheet layout.
-        /// - Parameters:
-        ///   - cornerRadius: corner radius of bottom sheet view.
+        public static let `default` = Layout()
 
         // Initializes a bottom sheet layout.
         /// - Parameters:
-        ///   - cornerRadius: corner radius of bottom sheet view.
+        ///   - cornerRadius: corner radius of bottom sheet view. Default is `16`.
         ///   - minimumTopOffset: minimum top offset. Default is `44`.
         ///   - maximumContentHeight: maximum content height of sheet. Default is `nil`.
         ///   - idealContentHeight: ideal content height of sheet. Default is `nil`.
         ///   - minimumContentHeight: minimum content height of sheet. Default is `88`.
         public init(
-            cornerRadius: CGFloat,
+            cornerRadius: CGFloat = 16,
             minimumTopOffset: CGFloat = 44,
             maximumContentHeight: CGFloat? = nil,
             idealContentHeight: CGFloat? = nil,

--- a/Sources/YBottomSheet/BottomSheetController+Appearance.swift
+++ b/Sources/YBottomSheet/BottomSheetController+Appearance.swift
@@ -28,14 +28,6 @@ extension BottomSheetController {
         public var presentAnimationCurve: UIView.AnimationOptions
         /// Animation type during dismissing. Default is `curveEaseOut`.
         public var dismissAnimationCurve: UIView.AnimationOptions
-        /// Minimum top offset of sheet from safe area top. Default is `44`.
-        ///
-        /// The top of the sheet will not move beyond this gap from the top of the safe area.
-        public var minimumTopOffset: CGFloat
-        /// (Optional) Minimum content view height. Default is `nil`.
-        ///
-        /// Only applicable for resizable sheets. `nil` means to use the content view's intrinsic height as the minimum.
-        public var minimumContentHeight: CGFloat?
         /// Whether the sheet can be dismissed by swiping down or tapping on the dimmer. Default is `true`.
         ///
         /// The user can always dismiss the sheet from the close button if it is visible.
@@ -56,8 +48,6 @@ extension BottomSheetController {
         ///   - animationDuration: animation duration for bottom sheet. Default is `0.3`.
         ///   - presentAnimationCurve: animation type during presenting.
         ///   - dismissAnimationCurve: animation type during dismiss.
-        ///   - minimumTopOffset: minimum top offset. Default is `44`
-        ///   - minimumContentHeight: (optional) minimum content view height.
         ///   - isDismissAllowed: whether the sheet can be dismissed by swiping down or tapping on the dimmer.
         public init(
             indicatorAppearance: DragIndicatorView.Appearance? = nil,
@@ -68,8 +58,6 @@ extension BottomSheetController {
             animationDuration: TimeInterval = 0.3,
             presentAnimationCurve: UIView.AnimationOptions = .curveEaseIn,
             dismissAnimationCurve: UIView.AnimationOptions = .curveEaseOut,
-            minimumTopOffset: CGFloat = 44,
-            minimumContentHeight: CGFloat? = nil,
             isDismissAllowed: Bool = true
         ) {
             self.indicatorAppearance = indicatorAppearance
@@ -80,8 +68,6 @@ extension BottomSheetController {
             self.animationDuration = animationDuration
             self.presentAnimationCurve = presentAnimationCurve
             self.dismissAnimationCurve = dismissAnimationCurve
-            self.minimumTopOffset = minimumTopOffset
-            self.minimumContentHeight = minimumContentHeight
             self.isDismissAllowed = isDismissAllowed
         }
     }

--- a/Sources/YBottomSheet/BottomSheetController+build.swift
+++ b/Sources/YBottomSheet/BottomSheetController+build.swift
@@ -27,7 +27,7 @@ private extension BottomSheetController {
         if let backgroundColor = subview.backgroundColor,
            backgroundColor.rgbaComponents.alpha == 1 {
             // use the subview's background color for the sheet
-            sheetView.backgroundColor = backgroundColor
+            sheetContainerView.backgroundColor = backgroundColor
             // but we have to set the subview's background to nil or else
             // it will overflow the sheet and not be cropped by the corner radius.
             subview.backgroundColor = nil
@@ -58,7 +58,8 @@ private extension BottomSheetController {
         view.addSubview(dimmerView)
         view.addSubview(dimmerTapView)
         view.addSubview(sheetView)
-        sheetView.addSubview(stackView)
+        sheetView.addSubview(sheetContainerView)
+        sheetContainerView.addSubview(stackView)
         stackView.addArrangedSubview(indicatorContainer)
         stackView.addArrangedSubview(headerView)
         stackView.addArrangedSubview(contentView)
@@ -68,6 +69,7 @@ private extension BottomSheetController {
         dimmerView.constrainEdges()
         dimmerTapView.constrainEdges(.notBottom)
         dimmerTapView.constrain(.bottomAnchor, to: sheetView.topAnchor)
+        sheetContainerView.constrainEdges()
 
         sheetView.constrainEdges(.notTop)
         minimumTopOffsetAnchor = sheetView.constrain(
@@ -88,9 +90,8 @@ private extension BottomSheetController {
         )
         indicatorView.constrainCenter(.x)
 
-        stackView.constrain(.topAnchor, to: sheetView.topAnchor)
+        stackView.constrainEdges(.top)
         stackView.constrainEdges(.horizontal, to: view.safeAreaLayoutGuide)
-        stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide, relatedBy: .greaterThanOrEqual)
         stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide)
         contentView.constrainEdges(.horizontal)
         headerView.constrainEdges(.horizontal)

--- a/Sources/YBottomSheet/BottomSheetController+build.swift
+++ b/Sources/YBottomSheet/BottomSheetController+build.swift
@@ -75,6 +75,11 @@ private extension BottomSheetController {
             to: view.safeAreaLayoutGuide.topAnchor,
             relatedBy: .greaterThanOrEqual
         )
+        minimumContentHeightAnchor = contentView.constrain(
+            .heightAnchor,
+            relatedBy: .greaterThanOrEqual,
+            constant: appearance.layout.minimumContentHeight
+        )
 
         indicatorView.constrain(.bottomAnchor, to: indicatorContainer.bottomAnchor)
         indicatorTopAnchor = indicatorView.constrain(
@@ -86,8 +91,7 @@ private extension BottomSheetController {
         stackView.constrain(.topAnchor, to: sheetView.topAnchor)
         stackView.constrainEdges(.horizontal, to: view.safeAreaLayoutGuide)
         stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide, relatedBy: .greaterThanOrEqual)
-        stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide, priority: Priorities.sheetContentHugging)
-
+        stackView.constrainEdges(.bottom, to: view.safeAreaLayoutGuide)
         contentView.constrainEdges(.horizontal)
         headerView.constrainEdges(.horizontal)
     }

--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -37,9 +37,12 @@ public class BottomSheetController: UIViewController {
     /// Dimmer view.
     let dimmerView = UIView()
     /// Bottom sheet view.
-    let sheetView: UIView = {
+    let sheetView = UIView()
+    /// Bottom sheet container view.
+    let sheetContainerView: UIView = {
         let view = UIView()
         view.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
+        view.clipsToBounds = true
         view.backgroundColor = .systemBackground
         return view
     }()
@@ -50,11 +53,7 @@ public class BottomSheetController: UIViewController {
     /// Bottom sheet header view.
     public internal(set) var headerView: SheetHeaderView!
     /// Holds the sheet's child content (view or view controller).
-    let contentView: UIView = {
-        let view = UIView()
-        view.clipsToBounds = true
-        return view
-    }()
+    let contentView = UIView()
 
     /// Comprises the indicator view, the header view, and the content view.
     let stackView: UIStackView = {
@@ -145,7 +144,7 @@ public class BottomSheetController: UIViewController {
         
         guard shadowSize != sheetView.bounds.size else { return }
         updateShadow()
-        shadowSize = contentView.bounds.size
+        shadowSize = sheetView.bounds.size
     }
     
     /// Performing the accessibility escape gesture dismisses the bottom sheet.
@@ -167,7 +166,7 @@ public class BottomSheetController: UIViewController {
 internal extension BottomSheetController {
     func updateViewAppearance() {
         dimmerTapView.isAccessibilityElement = appearance.isDismissAllowed
-        sheetView.layer.cornerRadius = appearance.layout.cornerRadius
+        sheetContainerView.layer.cornerRadius = appearance.layout.cornerRadius
         minimumTopOffsetAnchor?.constant = appearance.layout.minimumTopOffset
         updateShadow()
         dimmerView.backgroundColor = appearance.dimmerColor
@@ -191,6 +190,10 @@ internal extension BottomSheetController {
         case .controller(let viewController):
             return viewController.layoutSize
         }
+    }
+
+    func updateShadow() {
+        appearance.elevation?.apply(layer: sheetView.layer, cornerRadius: appearance.layout.cornerRadius)
     }
 }
 
@@ -267,10 +270,6 @@ private extension BottomSheetController {
         childView.setContentCompressionResistancePriority(Priorities.sheetCompressionResistance, for: .vertical)
     }
     
-    func updateShadow() {
-        appearance.elevation?.apply(layer: sheetView.layer)
-    }
-
     func onDismiss() {
         dismiss(animated: true)
     }

--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -174,7 +174,6 @@ internal extension BottomSheetController {
         updateIndicatorView()
         updateHeaderView()
         updateChildView()
-        view.layoutIfNeeded()
     }
 
     func addGestures() {

--- a/Sources/YBottomSheet/BottomSheetController.swift
+++ b/Sources/YBottomSheet/BottomSheetController.swift
@@ -184,6 +184,15 @@ internal extension BottomSheetController {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(onDimmerTap))
         dimmerTapView.addGestureRecognizer(tapGesture)
     }
+
+    var childContentSize: CGSize {
+        switch content {
+        case .view(_, let view):
+            return view.layoutSize
+        case .controller(let viewController):
+            return viewController.layoutSize
+        }
+    }
 }
 
 private extension BottomSheetController {
@@ -237,14 +246,15 @@ private extension BottomSheetController {
         }
 
         // Enforce ideal height (if any)
-        // (otherwise sheet height defautls to childView.instrinsicContentSize.height)
-        if let ideal = appearance.layout.idealContentHeight {
+        // (otherwise sheet height defaults to childView.instrinsicContentSize.height)
+        let idealHeight = appearance.layout.idealContentHeight ?? childContentSize.height
+        if idealHeight > 0.0 {
             if let idealContentHeightAnchor = idealContentHeightAnchor {
-                idealContentHeightAnchor.constant = ideal
+                idealContentHeightAnchor.constant = idealHeight
             } else {
                 idealContentHeightAnchor = childView.constrain(
                     .heightAnchor,
-                    constant: ideal,
+                    constant: idealHeight,
                     priority: Priorities.idealContentSize
                 )
             }

--- a/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView+Appearance+Layout.swift
+++ b/Sources/YBottomSheet/DragIndicatorView/DragIndicatorView+Appearance+Layout.swift
@@ -1,5 +1,5 @@
 //
-//  DragIndicatorView.Appearance+Layout.swift
+//  DragIndicatorView+Appearance+Layout.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 05/01/23.

--- a/Sources/YBottomSheet/Enums/BottomSheetController+Enums.swift
+++ b/Sources/YBottomSheet/Enums/BottomSheetController+Enums.swift
@@ -12,9 +12,8 @@ internal extension BottomSheetController {
     /// Priorities for various non-required constraints.
     enum Priorities {
         static let panGesture = UILayoutPriority(775)
-        static let sheetContentHugging = UILayoutPriority(751)
-        static let sheetCompressionResistanceLow = UILayoutPriority.defaultLow
-        static let sheetCompressionResistanceHigh = UILayoutPriority(800)
+        static let idealContentSize = UILayoutPriority(251)
+        static let sheetCompressionResistance = UILayoutPriority.defaultLow
     }
 
     /// Types of content that can populate a bottom sheet

--- a/Sources/YBottomSheet/Protocols/LayoutSizable.swift
+++ b/Sources/YBottomSheet/Protocols/LayoutSizable.swift
@@ -1,0 +1,71 @@
+//
+//  LayoutSizable.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 5/1/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import UIKit
+
+/// Represents any view or view controller that knows how to size itself
+@objc
+public protocol LayoutSizable {
+    /// Ideal layout size
+    @objc var layoutSize: CGSize { get }
+}
+
+extension UIView: LayoutSizable {
+    /// By default calls `systemLayoutSizeFitting`
+    @objc
+    open var layoutSize: CGSize {
+        systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+    }
+}
+
+extension UIScrollView {
+    /// By default returns `contentSize`
+    @objc
+    open override var layoutSize: CGSize {
+        contentSize
+    }
+}
+
+extension UITableView {
+    /// By default returns `contentSize`
+    @objc
+    open override var layoutSize: CGSize {
+        reloadData()
+        return super.layoutSize
+    }
+}
+
+extension UICollectionView {
+    /// By default returns the layout's `collectionViewContentSize`
+    @objc
+    open override var layoutSize: CGSize {
+        collectionViewLayout.collectionViewContentSize
+    }
+}
+
+extension UIViewController: LayoutSizable {
+    /// A view controller's layout size is that of its view
+    @objc
+    open var layoutSize: CGSize {
+        view.layoutSize
+    }
+}
+
+extension UINavigationController {
+    /// For navigation controller the ideal layout size is that of its child controller combined
+    /// with the navigation bar height
+    @objc
+    open override var layoutSize: CGSize {
+        let barHeight = navigationBar.intrinsicContentSize.height
+        var childSize: CGSize = .zero
+        if let child = children.last {
+            childSize = child.layoutSize
+        }
+        return CGSize(width: childSize.width, height: barHeight + childSize.height)
+    }
+}

--- a/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView+Appearance+Layout.swift
+++ b/Sources/YBottomSheet/SheetHeaderView/SheetHeaderView+Appearance+Layout.swift
@@ -1,5 +1,5 @@
 //
-//  SheetHeaderView.Appearance+Layout.swift
+//  SheetHeaderView+Appearance+Layout.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 17/01/23.

--- a/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
@@ -13,13 +13,20 @@ final class BottomSheetControllerAppearanceLayoutTests: XCTestCase {
     func test_propertiesDefaultValue() {
         let sut = BottomSheetController.Appearance.Layout.default
         XCTAssertEqual(sut.cornerRadius, 16)
+        XCTAssertEqual(sut.minimumTopOffset, 44)
+        XCTAssertNil(sut.maximumContentHeight)
+        XCTAssertNil(sut.idealContentHeight)
+        XCTAssertEqual(sut.minimumContentHeight, 88)
     }
     
     func test_propertiesWithRandomValues() {
         let radius = CGFloat(Int.random(in: 1...15))
+        let idealHeight = CGFloat(Int.random(in: 128...512))
         let sut = BottomSheetController.Appearance.Layout(
-            cornerRadius: radius
+            cornerRadius: radius,
+            idealContentHeight: idealHeight
         )
         XCTAssertEqual(sut.cornerRadius, radius)
+        XCTAssertEqual(sut.idealContentHeight, idealHeight)
     }
 }

--- a/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
@@ -1,5 +1,5 @@
 //
-//  BottomSheetAppearanceLayoutTests.swift
+//  BottomSheetController+Appearance+LayoutTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 19/01/23.
@@ -9,7 +9,7 @@
 import XCTest
 @testable import YBottomSheet
 
-final class BottomSheetAppearanceLayoutTests: XCTestCase {
+final class BottomSheetControllerAppearanceLayoutTests: XCTestCase {
     func test_propertiesDefaultValue() {
         let sut = BottomSheetController.Appearance.Layout.default
         XCTAssertEqual(sut.cornerRadius, 16)

--- a/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetController+Appearance+LayoutTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import YBottomSheet
 
-final class BottomSheetControllerAppearanceLayoutTests: XCTestCase {
+final class BottomSheetAppearanceLayoutTests: XCTestCase {
     func test_propertiesDefaultValue() {
         let sut = BottomSheetController.Appearance.Layout.default
         XCTAssertEqual(sut.cornerRadius, 16)

--- a/Tests/YBottomSheetTests/BottomSheetController+AppearanceTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetController+AppearanceTests.swift
@@ -22,8 +22,6 @@ final class BottomSheetControllerAppearanceTests: XCTestCase {
         XCTAssertEqual(sut.animationDuration, 0.3)
         XCTAssertEqual(sut.presentAnimationCurve, .curveEaseIn)
         XCTAssertEqual(sut.dismissAnimationCurve, .curveEaseOut)
-        XCTAssertEqual(sut.minimumTopOffset, 44)
-        XCTAssertNil(sut.minimumContentHeight)
         XCTAssertTrue(sut.isDismissAllowed)
     }
 }

--- a/Tests/YBottomSheetTests/BottomSheetController+AppearanceTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetController+AppearanceTests.swift
@@ -1,5 +1,5 @@
 //
-//  BottomSheetControllerAppearanceTests.swift
+//  BottomSheetController+AppearanceTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 19/01/23.

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -99,13 +99,13 @@ final class BottomSheetControllerTests: XCTestCase {
         let cornerRadius = CGFloat(Int.random(in: 1...7))
 
         XCTAssertEqual(
-            sut.sheetView.layer.cornerRadius,
+            sut.sheetContainerView.layer.cornerRadius,
             BottomSheetController.Appearance.Layout.default.cornerRadius
         )
 
         sut.appearance.layout.cornerRadius = cornerRadius
 
-        XCTAssertEqual(sut.sheetView.layer.cornerRadius, cornerRadius)
+        XCTAssertEqual(sut.sheetContainerView.layer.cornerRadius, cornerRadius)
     }
 
     func test_changeBeforeLoad_hasNoEffect() {
@@ -114,7 +114,7 @@ final class BottomSheetControllerTests: XCTestCase {
 
         sut.appearance.layout.cornerRadius = cornerRadius
 
-        XCTAssertNotEqual(sut.sheetView.layer.cornerRadius, cornerRadius)
+        XCTAssertNotEqual(sut.sheetContainerView.layer.cornerRadius, cornerRadius)
     }
 
     func test_hideHeaderView() {
@@ -422,8 +422,9 @@ final class BottomSheetControllerTests: XCTestCase {
 
         sut.loadViewIfNeeded()
 
+        XCTAssertNil(sut.sheetView.backgroundColor)
         XCTAssertEqual(
-            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            sut.sheetContainerView.backgroundColor?.resolvedColor(with: traits),
             color.resolvedColor(with: traits)
         )
         XCTAssertNil(view.backgroundColor)
@@ -437,8 +438,9 @@ final class BottomSheetControllerTests: XCTestCase {
 
         sut.loadViewIfNeeded()
 
+        XCTAssertNil(sut.sheetView.backgroundColor)
         XCTAssertEqual(
-            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            sut.sheetContainerView.backgroundColor?.resolvedColor(with: traits),
             UIColor.systemBackground.resolvedColor(with: traits)
         )
     }
@@ -451,8 +453,9 @@ final class BottomSheetControllerTests: XCTestCase {
 
         sut.loadViewIfNeeded()
 
+        XCTAssertNil(sut.sheetView.backgroundColor)
         XCTAssertEqual(
-            sut.sheetView.backgroundColor?.resolvedColor(with: traits),
+            sut.sheetContainerView.backgroundColor?.resolvedColor(with: traits),
             UIColor.systemBackground.resolvedColor(with: traits)
         )
     }

--- a/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
+++ b/Tests/YBottomSheetTests/BottomSheetControllerTests.swift
@@ -203,7 +203,7 @@ final class BottomSheetControllerTests: XCTestCase {
             indicatorAppearance: .default
         )
         let sut = SpyBottomSheetController(title: "", childView: ChildView(), appearance: appearance)
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         let gesture = MockPanGesture()
         gesture.state = .began
@@ -226,7 +226,7 @@ final class BottomSheetControllerTests: XCTestCase {
             layout: BottomSheetController.Appearance.Layout(cornerRadius: 16, minimumContentHeight: 150)
         )
         let sut = SpyBottomSheetController(title: "", childView: ChildView(), appearance: appearance)
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         let gesture = MockPanGesture()
         gesture.state = .began
@@ -250,7 +250,7 @@ final class BottomSheetControllerTests: XCTestCase {
             layout: BottomSheetController.Appearance.Layout(cornerRadius: 16, maximumContentHeight: maximum)
         )
         let sut = SpyBottomSheetController(title: "", childView: ChildView(), appearance: appearance)
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         let gesture = MockPanGesture()
         gesture.state = .began
@@ -270,12 +270,13 @@ final class BottomSheetControllerTests: XCTestCase {
 
         let newMaximum: CGFloat = 320
         sut.appearance.layout.maximumContentHeight = newMaximum
+        sut.view.layoutIfNeeded()
         XCTAssertEqual(sut.contentView.bounds.height, newMaximum)
     }
 
     func test_draggingDown_doesResizeViewBelowIntrinsicSize() {
         let sut = SpyBottomSheetController(title: "", childView: ChildView(), appearance: .defaultResizable)
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         let gesture = MockPanGesture()
         gesture.state = .began
@@ -296,7 +297,7 @@ final class BottomSheetControllerTests: XCTestCase {
         let sut = SpyBottomSheetController(title: "", childView: MiniView(), appearance: .defaultResizable)
         let minimum = CGFloat(Int.random(in: 32...128))
         sut.appearance.layout.minimumContentHeight = minimum
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         let gesture = MockPanGesture()
         gesture.state = .began
@@ -465,11 +466,12 @@ final class BottomSheetControllerTests: XCTestCase {
                 layout: BottomSheetController.Appearance.Layout(idealContentHeight: ideal)
             )
         )
-        sut.loadViewIfNeeded()
+        sut.view.layoutIfNeeded()
 
         XCTAssertEqual(sut.contentView.bounds.height, ideal)
         let newIdeal: CGFloat = 200
         sut.appearance.layout.idealContentHeight = newIdeal
+        sut.view.layoutIfNeeded()
         XCTAssertEqual(sut.contentView.bounds.height, newIdeal)
     }
 }

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorView+Appearance+LayoutTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorView+Appearance+LayoutTests.swift
@@ -1,5 +1,5 @@
 //
-//  DragIndicatorViewAppearanceLayoutTests.swift
+//  DragIndicatorView+Appearance+LayoutTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 03/01/23.

--- a/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorView+AppearanceTests.swift
+++ b/Tests/YBottomSheetTests/DragIndicatorView/DragIndicatorView+AppearanceTests.swift
@@ -1,5 +1,5 @@
 //
-//  DragIndicatorViewAppearanceTests.swift
+//  DragIndicatorView+AppearanceTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 03/01/23.

--- a/Tests/YBottomSheetTests/Protocols/LayoutSizableTests.swift
+++ b/Tests/YBottomSheetTests/Protocols/LayoutSizableTests.swift
@@ -1,0 +1,118 @@
+//
+//  LayoutSizableTests.swift
+//  YBottomSheet
+//
+//  Created by Mark Pospesel on 5/3/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+import YCoreUI
+@testable import YBottomSheet
+
+final class LayoutSizableTests: XCTestCase {
+    func test_viewLayoutSize_deliversZeroSize() {
+        let sut = UIView()
+
+        XCTAssertEqual(sut.layoutSize, .zero)
+    }
+
+    func test_labelLayoutSize_deliversNonZeroSize() {
+        let sut = UILabel()
+        sut.text = "Hello"
+
+        XCTAssertNotEqual(sut.layoutSize, .zero)
+    }
+
+    func test_scrollViewLayoutSize_deliversContentSize() {
+        let sut = UIScrollView()
+        let label = UILabel()
+        let insets = NSDirectionalEdgeInsets(all: CGFloat(Int.random(in: 1...32)))
+        label.text = "Hello\nWorld"
+        sut.addSubview(label)
+        label.constrainEdges(with: insets)
+        sut.layoutIfNeeded()
+
+        XCTAssertNotEqual(sut.layoutSize, .zero)
+        XCTAssertNotEqual(sut.layoutSize, label.layoutSize)
+        XCTAssertEqual(
+            sut.layoutSize.height.ceiled(),
+            (label.layoutSize.height + insets.vertical).ceiled()
+        )
+    }
+
+    func test_tableViewLayoutSize_deliversContentSize() {
+        let sut = UITableView()
+        let dataSource = GroceryList()
+        sut.rowHeight = 44
+        sut.dataSource = dataSource
+
+        XCTAssertEqual(
+            sut.layoutSize.height,
+            (44 * CGFloat(dataSource.items.count))
+        )
+    }
+
+    func test_collectionViewLayoutSize_deliversContentSize() {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .vertical
+
+        let sut = UICollectionView(frame: UIScreen.main.bounds, collectionViewLayout: layout)
+        let dataSource = GroceryList()
+        sut.dataSource = dataSource
+
+        XCTAssertNotEqual(sut.layoutSize, .zero)
+    }
+
+    func test_navigationControllerLayoutSize_deliversBarHeightPlusChildLayoutSize() {
+        let vc = UIViewController()
+        let child = ChildView()
+        vc.view.addSubview(child)
+        child.constrainEdges()
+        vc.view.layoutIfNeeded()
+
+        let sut = UINavigationController(rootViewController: vc)
+
+        XCTAssertEqual(vc.layoutSize, CGSize(width: 300, height: 300))
+        XCTAssertEqual(sut.layoutSize.height, sut.navigationBar.bounds.height + vc.layoutSize.height)
+    }
+}
+
+class GroceryList: NSObject {
+    var items = [
+        "Milk",
+        "Orange Juice",
+        "Bananas",
+        "Zebras"
+    ]
+}
+
+extension GroceryList: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        cell.textLabel?.text = items[indexPath.row]
+        return cell
+    }
+}
+
+extension GroceryList: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        items.count
+    }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        let cell = UICollectionViewCell()
+        let label = UILabel()
+        label.text = items[indexPath.row]
+        cell.contentView.addSubview(label)
+        label.constrainEdges()
+        return cell
+    }
+}

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderView+Appearance+LayoutTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderView+Appearance+LayoutTests.swift
@@ -1,5 +1,5 @@
 //
-//  SheetHeaderViewAppearanceLayoutTests.swift
+//  SheetHeaderView+Appearance+LayoutTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 17/01/23.

--- a/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderView+AppearanceTests.swift
+++ b/Tests/YBottomSheetTests/SheetHeaderView/SheetHeaderView+AppearanceTests.swift
@@ -1,5 +1,5 @@
 //
-//  SheetHeaderViewAppearanceTests.swift
+//  SheetHeaderView+AppearanceTests.swift
 //  YBottomSheet
 //
 //  Created by Dev Karan on 17/01/23.


### PR DESCRIPTION
## Introduction ##

When displaying a navigation controller or a table view controller in the bottom sheet, the sheet doesn't size itself correctly.

## Purpose ##

Fix #22

## Scope ##

* Move sheet size constraint properties from appearance to layout
* Expand these constraint properties to include minimum, ideal, and maximum content sizes
* Add mechanism for different views and view controllers to report their ideal size
* Separate the view that has masked corners (must be clipped) from the view that has the sheet's shadow (clipping removes any shadow so cannot be the same view as the one clipping the corners)

## Out of Scope ##

Call out any known issues that are purposely not addressed in this pull request.

## 📱 Screenshots ##

| Test Case | Before | After |
| --- | --- | --- |
| Navigation | ![bs_22_before_3](https://user-images.githubusercontent.com/1037520/235889998-7a16dcf3-d2c0-449b-a13d-68f5d926d86d.png) | ![bs_22_after_3](https://user-images.githubusercontent.com/1037520/235890002-7a81733c-6330-4188-adc2-f01401861db9.png) |
| Table with 4 items (note missing corner curve) | ![bs_22_before_4](https://user-images.githubusercontent.com/1037520/235890098-8dd3afa5-af7e-4fc9-954d-82470710eceb.png) | ![bs_22_after_4](https://user-images.githubusercontent.com/1037520/235890094-80798778-b009-47ea-8b64-7aef1263a03e.png) |
| Navigation + Table with 4 items | ![bs_22_before_5](https://user-images.githubusercontent.com/1037520/235890187-ab226586-996c-4e4f-b416-11e309b356a8.png) | ![bs_22_after_5](https://user-images.githubusercontent.com/1037520/235890188-bf0d716f-3416-4052-9aa1-b3d403861394.png) |

## 📈 Coverage ##

##### Code #####

100%

<img width="687" alt="image" src="https://user-images.githubusercontent.com/1037520/235890713-ce974d18-88c0-4805-97df-6125f44a727a.png">

##### Documentation #####

100%

<img width="622" alt="image" src="https://user-images.githubusercontent.com/1037520/235890807-bbdfb07e-82f0-4128-89a6-0f4a44968e9b.png">
